### PR TITLE
Fix Bug in ListView

### DIFF
--- a/source/samples/SamplesCommon/LayoutDensitySelector.xaml.cs
+++ b/source/samples/SamplesCommon/LayoutDensitySelector.xaml.cs
@@ -43,7 +43,7 @@ namespace SamplesCommon
         {
             if (_compactResources == null)
             {
-                _compactResources = new ResourceDictionary { Source = new Uri("/iNKORE.UI.WPF.Modern;component/Density/iNKORE.UI.WPF.Modern;component/Themes/Styles/Compact.xaml", UriKind.Relative) };
+                _compactResources = new ResourceDictionary { Source = new Uri("/iNKORE.UI.WPF.Modern;component/Themes/DensityStyles/Compact.xaml", UriKind.Relative) };
                 TargetElement?.Resources.MergedDictionaries.Add(_compactResources);
             }
         }


### PR DESCRIPTION
I have addressed an issue within the ListView component where the application would encounter a crash upon selecting the compact view. This occurred due to an incorrect configuration of the resource URI.

I acknowledge that this correction does not directly enhance the codebase. However, upon recently discovering and acquiring the library, I engaged in an exploratory examination of the code. During this process, I identified the aforementioned bug and subsequently rectified it.