### PR TITLE
Fix NoResize Mode and Caption Color

### DIFF
--- a/samples/WpfApp1/MainWindow.xaml
+++ b/samples/WpfApp1/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:WpfApp1" xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800"
-        ResizeMode="CanMinimize"
+        ResizeMode="NoResize"
         ui:ThemeManager.IsThemeAware="True" ui:TitleBar.Height="40"
         ui:TitleBar.ExtendViewIntoTitleBar="False" ui:WindowHelper.SystemBackdropType="Acrylic"
         ui:TitleBar.ButtonCloseAvailability="Enabled"

--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/WindowHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/WindowHelper.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Shell;
 
 namespace iNKORE.UI.WPF.Modern.Controls.Helpers
 {
@@ -424,6 +425,13 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
                         window.SetResourceReference(FrameworkElement.StyleProperty, DefaultWindowStyleKey);
                     }
                 }
+
+                if (window.ResizeMode == ResizeMode.NoResize)
+                {
+					var chrome = WindowChrome.GetWindowChrome(window); 
+                    chrome.ResizeBorderThickness = new Thickness(0); 
+                    WindowChrome.SetWindowChrome(window, chrome);
+				}
             }
             else
             {

--- a/source/iNKORE.UI.WPF.Modern/Helpers/Styles/MicaHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Helpers/Styles/MicaHelper.cs
@@ -74,7 +74,12 @@ namespace iNKORE.UI.WPF.Modern.Helpers.Styles
 
             if (handle == IntPtr.Zero) { return false; }
 
-            return type switch
+			var captionColor = -2; //DWMWA_COLOR_NONE - 0xFFFFFFFE
+			DWMAPI.DwmSetWindowAttribute(handle, DWMAPI.DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR,
+				ref captionColor,
+				Marshal.SizeOf(typeof(int)));
+
+			return type switch
             {
                 BackdropType.None => TryApplyNone(handle),
                 BackdropType.Mica => TryApplyMica(handle),
@@ -116,7 +121,12 @@ namespace iNKORE.UI.WPF.Modern.Helpers.Styles
             DWMAPI.DwmSetWindowAttribute(handle, DWMAPI.DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE,
                 ref backdropPvAttribute,
                 Marshal.SizeOf(typeof(int)));
-        }
+
+			var captionColor = -1; //DWMWA_COLOR_DEFAULT - 0xFFFFFFFF
+			DWMAPI.DwmSetWindowAttribute(handle, DWMAPI.DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR,
+				ref captionColor,
+				Marshal.SizeOf(typeof(int)));
+		}
 
         /// <summary>
         /// Tries to inform the operating system that this window uses dark mode.


### PR DESCRIPTION
#59 
This only works if 'NoResize' is before 'UseModernWindowStyle'

![captioncolor](https://github.com/iNKORE-NET/UI.WPF.Modern/assets/17840111/41ac9e6f-7706-48d8-9cab-f2d6c4fd3fff)
If we use backdrop, windows applies an accent color to the title bar (this is related to an option in the system settings)

