### PR TITLE
[Enhancement] NavigationViewItem 

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.cs
@@ -1777,7 +1777,6 @@ namespace iNKORE.UI.WPF.Modern.Controls
         // Call this when you want an uncancellable close
         void ClosePane()
         {
-            CollapseMenuItemsInRepeater(m_leftNavRepeater);
             try
             {
                 m_isOpenPaneForInteraction = true;

--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationViewItemPresenter.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationViewItemPresenter.cs
@@ -124,6 +124,7 @@ namespace iNKORE.UI.WPF.Modern.Controls.Primitives
                 {
                     m_expandCollapseChevron = expandCollapseChevron;
                     InputHelper.SetIsTapEnabled(expandCollapseChevron, true);
+                    InputHelper.SetStopRouting(expandCollapseChevron, true);
                     InputHelper.AddTappedHandler(expandCollapseChevron, navigationViewItem.OnExpandCollapseChevronTapped);
                 }
                 navigationViewItem.UpdateVisualStateNoTransition();

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Navigation/NavigationRootPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Navigation/NavigationRootPage.xaml
@@ -81,7 +81,7 @@
             IsTitleBarAutoPaddingEnabled="False"
             Loaded="OnNavigationViewControlLoaded"
             PaneClosing="NavigationViewControl_PaneClosing"
-            PaneDisplayMode="Auto"
+            PaneDisplayMode="Left"
             PaneOpening="NavigationViewControl_PaneOpening"
             SelectionChanged="OnNavigationViewSelectionChanged"
             IsSettingsVisible="True">

--- a/source/iNKORE.UI.WPF.Modern/Input/InputHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Input/InputHelper.cs
@@ -119,14 +119,7 @@ namespace iNKORE.UI.WPF.Modern.Input
 
         public static void SetStopRouting(UIElement element, bool value)
         {
-            if (value)
-            {
-                element.SetValue(StopRoutingProperty, value);
-            }
-            else
-            {
-                element.ClearValue(StopRoutingProperty);
-            }
+            element.SetValue(StopRoutingProperty, value);
         }
         #endregion
 

--- a/source/iNKORE.UI.WPF.Modern/Input/InputHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Input/InputHelper.cs
@@ -104,6 +104,32 @@ namespace iNKORE.UI.WPF.Modern.Input
 
         #endregion
 
+        #region StopRouting
+        public static readonly DependencyProperty StopRoutingProperty =
+            DependencyProperty.RegisterAttached(
+                "StopRouting",
+                typeof(bool),
+                typeof(InputHelper),
+                new PropertyMetadata(false));
+
+        public static bool GetStopRouting(UIElement element)
+        {
+            return (bool)element.GetValue(StopRoutingProperty);
+        }
+
+        public static void SetStopRouting(UIElement element, bool value)
+        {
+            if (value)
+            {
+                element.SetValue(StopRoutingProperty, value);
+            }
+            else
+            {
+                element.ClearValue(StopRoutingProperty);
+            }
+        }
+        #endregion
+
         private static void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var element = (UIElement)sender;
@@ -111,6 +137,12 @@ namespace iNKORE.UI.WPF.Modern.Input
             if (!GetIsPressed(element))
             {
                 SetIsPressed(element, true);
+                
+                if (GetStopRouting(element))
+                {
+                    element.CaptureMouse();
+                    e.Handled = true;
+                }
             }
         }
 
@@ -121,6 +153,11 @@ namespace iNKORE.UI.WPF.Modern.Input
             if (GetIsPressed(element))
             {
                 SetIsPressed((UIElement)sender, false);
+
+                if (GetStopRouting(element))
+                {
+                    element.ReleaseMouseCapture();
+                }
 
                 var lastArgs = _lastTappedArgs;
 


### PR DESCRIPTION
fix #83 
fix #138

navigationview item button no longer changes selection.
pane collapse/expand retains selected item.

fix:

https://github.com/user-attachments/assets/852e596f-8a89-4470-b580-d5a8e6cdb37a

winui gallery:

https://github.com/user-attachments/assets/ebd75c7f-e151-4e01-992c-ea2dc537a42f

