### PR TITLE
[BugFix] NavigationView initial state

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.properties.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.properties.cs
@@ -35,13 +35,12 @@ namespace iNKORE.UI.WPF.Modern.Controls
         #endregion
 
         #region IsPaneOpen
-
         public static readonly DependencyProperty IsPaneOpenProperty =
             DependencyProperty.Register(
                 nameof(IsPaneOpen),
                 typeof(bool),
                 typeof(NavigationView),
-                new PropertyMetadata(true, OnIsPaneOpenPropertyChanged));
+                new PropertyMetadata(false, OnIsPaneOpenPropertyChanged));
 
         public bool IsPaneOpen
         {


### PR DESCRIPTION
When creating a navigation view without specifying IsPaneOpen, there is inconsistencies in styles between the navigationview itself and its items.

Update IsPaneOpen default value to false

Resolve #142 