### PR TITLE
[Enhancement] Focus Navigation for CommandBar

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/CommandBarFlyout/CommandBarFlyoutToolBar.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/CommandBarFlyout/CommandBarFlyoutToolBar.cs
@@ -693,6 +693,17 @@ namespace iNKORE.UI.WPF.Modern.Controls.Primitives
             }
         }
 
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            if (e.Key is Key.Up && m_moreButton.IsFocused && PrimaryCommands.Count > 0 && PrimaryCommands[PrimaryCommands.Count - 1] is
+                    Control toFocusCommand)
+            {
+                e.Handled = FocusControl(toFocusCommand, m_moreButton, true);
+            }
+
+            base.OnPreviewKeyDown(e);
+        }
+
         protected override void OnKeyDown(KeyEventArgs args)
         {
             if (args.Handled)


### PR DESCRIPTION
- keyboard focus navigation for command bar
- fixed a case for command bar flyout where up key didn't work on MoreButton
- fixes #284 
