### PR TITLE
Gallery Revamp: Expander Page 

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/ExpanderPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/ExpanderPage.xaml
@@ -12,7 +12,7 @@
     Loaded="Page_Loaded"
     mc:Ignorable="d">
     <StackPanel>
-        <local:ControlExample x:Name="Example1" HeaderText="An card-like style expander with text in the header and content areas">
+        <local:ControlExample x:Name="Example1" HeaderText="An card-like style Expander with text in the header and content areas">
             <local:ControlExample.Example>
                 <Expander
                     x:Name="Expander1"
@@ -40,7 +40,7 @@
             </local:ControlExample.Options>
         </local:ControlExample>
 
-        <local:ControlExample x:Name="Example2" HeaderText="An card-like style expander with other controls in the header and content">
+        <local:ControlExample x:Name="Example2" HeaderText="An card-like style Expander with other controls in the header and content">
             <local:ControlExample.Example>
                 <Expander x:Name="Expander2" Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}">
                     <Expander.Header>
@@ -55,7 +55,7 @@
             </local:ControlExample.Example>
         </local:ControlExample>
 
-        <local:ControlExample x:Name="Example3" HeaderText="Modifying card-like style expander content alignment">
+        <local:ControlExample x:Name="Example3" HeaderText="Modifying card-like style Expander content alignment">
             <local:ControlExample.Example>
                 <Expander
                     Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}"

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/ExpanderPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/ExpanderPage.xaml
@@ -1,4 +1,4 @@
-﻿<ui:Page
+<ui:Page
     x:Class="iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows.ExpanderPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -12,11 +12,13 @@
     Loaded="Page_Loaded"
     mc:Ignorable="d">
     <StackPanel>
-        <local:ControlExample x:Name="Example1" HeaderText="An Expander with text in the header and content areas">
+        <local:ControlExample x:Name="Example1" HeaderText="An card-like style expander with text in the header and content areas">
             <local:ControlExample.Example>
                 <Expander
                     x:Name="Expander1"
+                    Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}"
                     VerticalAlignment="Top"
+                    HorizontalContentAlignment="Left"
                     Content="This is in the content"
                     ExpandDirection="Down"
                     Header="This text is in the header"
@@ -38,9 +40,9 @@
             </local:ControlExample.Options>
         </local:ControlExample>
 
-        <local:ControlExample x:Name="Example2" HeaderText="An Expander with other controls in the header and content">
+        <local:ControlExample x:Name="Example2" HeaderText="An card-like style expander with other controls in the header and content">
             <local:ControlExample.Example>
-                <Expander x:Name="Expander2">
+                <Expander x:Name="Expander2" Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}">
                     <Expander.Header>
                         <ToggleButton Content="This is a ToggleButton in the header" />
                     </Expander.Header>
@@ -53,9 +55,10 @@
             </local:ControlExample.Example>
         </local:ControlExample>
 
-        <local:ControlExample x:Name="Example3" HeaderText="Modifying Expanders content alignment">
+        <local:ControlExample x:Name="Example3" HeaderText="Modifying card-like style expander content alignment">
             <local:ControlExample.Example>
                 <Expander
+                    Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}"
                     Width="500"
                     Padding="0"
                     HorizontalContentAlignment="Left">
@@ -69,15 +72,72 @@
             </local:ControlExample.Example>
         </local:ControlExample>
 
-        <local:ControlExample x:Name="Example4" HeaderText="Expander with a card-like style">
+        <!-- <local:ControlExample x:Name="Example4" HeaderText="Expander with a card-like style">
             <local:ControlExample.Example>
                 <Expander
+                    Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}"z
                     Width="500"
-                    Style="{StaticResource {x:Static ui:ThemeKeys.ExpanderCardStyleKey}}"
                     Content="This is in the content"
                     ExpandDirection="Down"
                     Header="This text is in the header"
                     HorizontalContentAlignment="Left">
+                </Expander>
+            </local:ControlExample.Example>
+        </local:ControlExample> -->
+
+        <local:ControlExample x:Name="Example5" HeaderText="An Expander with text in the header and content areas">
+            <local:ControlExample.Example>
+                <Expander
+                    x:Name="Expander5"
+                    VerticalAlignment="Top"
+                    Content="This is in the content"
+                    ExpandDirection="Down"
+                    Header="This text is in the header"
+                    IsExpanded="False" />
+            </local:ControlExample.Example>
+            <local:ControlExample.Options>
+                <StackPanel>
+                    <ComboBox
+                        x:Name="ExpandDirectionComboBox5"
+                        ui:ControlHelper.Header="ExpandDirection"
+                        SelectedValue="Down"
+                        SelectionChanged="ExpandDirectionComboBox5_SelectionChanged">
+                        <sys:String>Down</sys:String>
+                        <sys:String>Up</sys:String>
+                        <sys:String>Left</sys:String>
+                        <sys:String>Right</sys:String>
+                    </ComboBox>
+                </StackPanel>
+            </local:ControlExample.Options>
+        </local:ControlExample>
+
+        <local:ControlExample x:Name="Example6" HeaderText="An Expander with other controls in the header and content">
+            <local:ControlExample.Example>
+                <Expander x:Name="Expander6">
+                    <Expander.Header>
+                        <ToggleButton Content="This is a ToggleButton in the header" />
+                    </Expander.Header>
+                    <Expander.Content>
+                        <Grid>
+                            <Button Margin="15" Content="This is a Button in the content" />
+                        </Grid>
+                    </Expander.Content>
+                </Expander>
+            </local:ControlExample.Example>
+        </local:ControlExample>
+
+        <local:ControlExample x:Name="Example7" HeaderText="Modifying Expander content alignment">
+            <local:ControlExample.Example>
+                <Expander
+                    Width="500"
+                    Padding="0"
+                    HorizontalContentAlignment="Left">
+                    <Expander.Header>
+                        <ToggleButton HorizontalAlignment="Center" Content="This ToggleButton is centered" />
+                    </Expander.Header>
+                    <Expander.Content>
+                        <Button Margin="4" Content="This Button is left aligned" />
+                    </Expander.Content>
                 </Expander>
             </local:ControlExample.Example>
         </local:ControlExample>

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/ExpanderPage.xaml.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/ExpanderPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using iNKORE.UI.WPF.Modern.Controls;
+using iNKORE.UI.WPF.Modern.Controls;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
@@ -49,8 +49,43 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows
             }
         }
 
+        private void ExpandDirectionComboBox5_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            string expandDirection = e.AddedItems[0].ToString();
+
+            switch (expandDirection)
+            {
+                case "Down":
+                default:
+                    Expander5.ExpandDirection = ExpandDirection.Down;
+                    Expander5.VerticalAlignment = VerticalAlignment.Top;
+                    break;
+
+                case "Up":
+                    Expander5.ExpandDirection = ExpandDirection.Up;
+                    Expander5.VerticalAlignment = VerticalAlignment.Bottom;
+                    break;
+
+                case "Left":
+                    Expander5.ExpandDirection = ExpandDirection.Left;
+                    Expander5.HorizontalAlignment = HorizontalAlignment.Right;
+                    break;
+
+                case "Right":
+                    Expander5.ExpandDirection = ExpandDirection.Right;
+                    Expander5.HorizontalAlignment = HorizontalAlignment.Left;
+                    break;
+            }
+
+            if (this.IsLoaded)
+            {
+                UpdateExampleCode();
+            }
+        }
+
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
+            // Setup bindings for Example 1
             ControlExampleSubstitution Substitution1 = new ControlExampleSubstitution
             {
                 Key = "IsExpanded",
@@ -94,6 +129,50 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows
             ObservableCollection<ControlExampleSubstitution> Substitutions = new ObservableCollection<ControlExampleSubstitution> { Substitution1, Substitution2, Substitution3, Substitution4 };
             Example1.Substitutions = Substitutions;
 
+            // Setup bindings for Example 5
+            ControlExampleSubstitution Substitution5 = new ControlExampleSubstitution
+            {
+                Key = "IsExpanded",
+            };
+            BindingOperations.SetBinding(Substitution5, ControlExampleSubstitution.ValueProperty, new Binding
+            {
+                Source = Expander5,
+                Path = new PropertyPath("IsExpanded"),
+            });
+
+            ControlExampleSubstitution Substitution6 = new ControlExampleSubstitution
+            {
+                Key = "ExpandDirection",
+            };
+            BindingOperations.SetBinding(Substitution6, ControlExampleSubstitution.ValueProperty, new Binding
+            {
+                Source = ExpandDirectionComboBox5,
+                Path = new PropertyPath("SelectedValue"),
+            });
+
+            ControlExampleSubstitution Substitution7 = new ControlExampleSubstitution
+            {
+                Key = "VerticalAlignment",
+            };
+            BindingOperations.SetBinding(Substitution7, ControlExampleSubstitution.ValueProperty, new Binding
+            {
+                Source = Expander5,
+                Path = new PropertyPath("VerticalAlignment"),
+            });
+
+            ControlExampleSubstitution Substitution8 = new ControlExampleSubstitution
+            {
+                Key = "HorizontalAlignment",
+            };
+            BindingOperations.SetBinding(Substitution8, ControlExampleSubstitution.ValueProperty, new Binding
+            {
+                Source = Expander5,
+                Path = new PropertyPath("HorizontalAlignment"),
+            });
+
+            ObservableCollection<ControlExampleSubstitution> Substitutions5 = new ObservableCollection<ControlExampleSubstitution> { Substitution5, Substitution6, Substitution7, Substitution8 };
+            Example5.Substitutions = Substitutions5;
+
             UpdateExampleCode();
         }
 
@@ -104,18 +183,22 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows
             Example1.Xaml = Example1Xaml;
             Example2.Xaml = Example2Xaml;
             Example3.Xaml = Example3Xaml;
-            Example4.Xaml = Example4Xaml;
+            // Example4.Xaml = Example4Xaml;
+            Example5.Xaml = Example5Xaml;
+            Example6.Xaml = Example6Xaml;
+            Example7.Xaml = Example7Xaml;
         }
 
         public string Example1Xaml => $@"
 <Expander x:Name=""Expander1""
+    Style=""{{StaticResource {{x:Static ui:ThemeKeys.ExpanderCardStyleKey}}}}""
     Content=""This is in the content""
     ExpandDirection=""{Expander1.ExpandDirection.ToString()}""
     Header=""This text is in the header"" />
 ";
 
         public string Example2Xaml => $@"
-<Expander x:Name=""Expander2"">
+<Expander x:Name=""Expander2"" Style=""{{StaticResource {{x:Static ui:ThemeKeys.ExpanderCardStyleKey}}}}"">
     <Expander.Header>
         <ToggleButton Content=""This is a ToggleButton in the header"" />
     </Expander.Header>
@@ -128,7 +211,7 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows
 ";
 
             public string Example3Xaml => $@"
-<Expander>
+<Expander Style=""{{StaticResource {{x:Static ui:ThemeKeys.ExpanderCardStyleKey}}}}"">
     <Expander.Header>
         <ToggleButton HorizontalAlignment=""Center"" Content=""This ToggleButton is centered"" />
     </Expander.Header>
@@ -138,11 +221,47 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows
 </Expander>
 ";
 
-        public string Example4Xaml => $@"
-<Expander ExpandDirection=""Down""
-    Style=""{{StaticResource {{x:Static ui:ThemeKeys.ExpanderCardStyleKey}}}}""
+//         public string Example4Xaml => $@"
+// <Expander Width=""500""
+//     Content=""This is in the content""
+//     ExpandDirection=""Down""
+//     Header=""This text is in the header""
+//     HorizontalContentAlignment=""Left"" />
+// ";
+
+        public string Example5Xaml => $@"
+<Expander x:Name=""Expander5""
+    VerticalAlignment=""Top""
     Content=""This is in the content""
-    Header=""This text is in the header"" />
+    ExpandDirection=""{Expander5.ExpandDirection.ToString()}""
+    Header=""This text is in the header""
+    IsExpanded=""False"" />
+";
+
+        public string Example6Xaml => $@"
+<Expander x:Name=""Expander6"">
+    <Expander.Header>
+        <ToggleButton Content=""This is a ToggleButton in the header"" />
+    </Expander.Header>
+    <Expander.Content>
+        <Grid>
+            <Button Margin=""15"" Content=""This is a Button in the content"" />
+        </Grid>
+    </Expander.Content>
+</Expander>
+";
+
+        public string Example7Xaml => $@"
+<Expander Width=""500""
+    Padding=""0""
+    HorizontalContentAlignment=""Left"">
+    <Expander.Header>
+        <ToggleButton HorizontalAlignment=""Center"" Content=""This ToggleButton is centered"" />
+    </Expander.Header>
+    <Expander.Content>
+        <Button Margin=""4"" Content=""This Button is left aligned"" />
+    </Expander.Content>
+</Expander>
 ";
 
         #endregion


### PR DESCRIPTION
This PR revamps the gallery page to highlight the ExpanderCardStyle as the primary Expander example to align with the project’s Fluent 2 design goals and aim for detailed example to showcase both expander style.

These updates prioritize the modern ExpanderCardStyle to encourage its adoption while retaining the default style for compatibility and legacy support. also to avoid confusion in the future.

<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/3c668486-6625-41fa-8861-d3863685133c" />
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/fff28f4d-977c-45b1-a851-0a48af58d09c" />
