### PR TITLE
[Fix] NavigationView: Fix issue that pane is not closed after switching from expanded mode to minimal directly

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.cs
@@ -1565,7 +1565,8 @@ namespace iNKORE.UI.WPF.Modern.Controls
             }
 
             if (previousMode == NavigationViewDisplayMode.Expanded
-                && displayMode == NavigationViewDisplayMode.Compact)
+                && (displayMode == NavigationViewDisplayMode.Compact ||
+                    displayMode == NavigationViewDisplayMode.Minimal))
             {
                 m_initialListSizeStateSet = false;
                 ClosePane();


### PR DESCRIPTION
If `ExpandedModeThresholdWidthProperty` is less than `CompactMinimalModeThresholdWidthProperty`, and `PaneDisplayMode` is `Auto`, the navigation view will switch from expanded mode to minimal mode directly. In that case, we should close pane as well.