### PR TITLE
Gallery Revamp: MessageBox Page

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Extended/MessageBoxPage.xaml.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Extended/MessageBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using iNKORE.UI.WPF.Modern.Controls;
+using iNKORE.UI.WPF.Modern.Controls;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -36,6 +36,7 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Extended
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
+            RadioButtons_DefaultBackdropStyle.SelectedItem = MessageBox.DefaultBackdropType;
             UpdateExampleCode();
         }
 


### PR DESCRIPTION
Make the radio button that not selected to actually selected (Default was mica) on MessageBox page
<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/93700e1f-ab2f-471c-92c4-16ffe02a3604" />