### PR TITLE
[Fix] NavigationView: Use Revoker to manage events

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationViewItem.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationViewItem.cs
@@ -106,9 +106,9 @@ namespace iNKORE.UI.WPF.Modern.Controls
 
             if (GetSplitView() is { } splitView)
             {
-                splitView.IsPaneOpenChanged += OnSplitViewPropertyChanged;
-                splitView.DisplayModeChanged += OnSplitViewPropertyChanged;
-                splitView.CompactPaneLengthChanged += OnSplitViewPropertyChanged;
+                m_splitViewIsPaneOpenChangedRevoker = new(splitView, OnSplitViewPropertyChanged);
+                m_splitViewDisplayModeChangedRevoker = new(splitView, OnSplitViewPropertyChanged);
+                m_splitViewCompactPaneLengthChangedRevoker = new(splitView, OnSplitViewPropertyChanged);
 
                 UpdateCompactPaneLength();
                 UpdateIsClosedCompact();


### PR DESCRIPTION
`m_splitViewIsPaneOpenChangedRevoker` is null here, I think developers may forget to use them