### PR TITLE
Fix: DatePicker and TimePicker TopHeaderMargin not aligned with other controls

### DIFF
--- a/source/iNKORE.UI.WPF.Modern/Themes/ThemeResources.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/ThemeResources.xaml
@@ -36,7 +36,7 @@
     <Thickness x:Key="ButtonPadding">11,5,11,5</Thickness>
 
     <!--  Resources for CalendarDatePicker  -->
-    <Thickness x:Key="CalendarDatePickerTopHeaderMargin">0,0,0,4</Thickness>
+    <Thickness x:Key="CalendarDatePickerTopHeaderMargin">0,0,0,8</Thickness>
 
     <!--  Resources for CheckBox  -->
     <sys:Double x:Key="CheckBoxBorderThickness">1</sys:Double>
@@ -512,7 +512,7 @@
     <sys:Double x:Key="TextBoxIconFontSize">12</sys:Double>
 
     <!--  Resources for TimePicker  -->
-    <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,4</Thickness>
+    <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,8</Thickness>
     <sys:Double x:Key="TimePickerFlyoutPresenterHighlightHeight">40</sys:Double>
     <sys:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</sys:Double>
     <sys:Double x:Key="TimePickerThemeMinWidth">242</sys:Double>
@@ -536,7 +536,7 @@
     
     <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
     <Thickness x:Key="DatePickerBorderThemeThickness">1</Thickness>
-    <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,4</Thickness>
+    <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,8</Thickness>
     <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
     <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,3,0,6</Thickness>
     <Thickness x:Key="DatePickerHostPadding">0,3,0,6</Thickness>


### PR DESCRIPTION
Set `CalendarDatePickerTopHeaderMargin` `TimePickerTopHeaderMargin` `DatePickerTopHeaderMargin` to `0,0,0,8` to keep up with the TopHeaderMargin of ComboBox, TextBox, etc.

When DatePicker and TimePicker have the property `ui:ControlHelper.Header` in XAML, their headers are closer to the pickers than other controls like ComboBox or TextBox. That's not awesome when putting DatePicker and ComboBox together as the image shown below. Maybe we can fix this by editing the file `ThemeResources.xaml`.

<img width="678" height="136" alt="image" src="https://github.com/user-attachments/assets/9a38ab65-0b9b-4fb2-8b78-2aa92e227f15" />
