### PR TITLE
Gallery Revamp: Design Iconography Page

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/Data/Controls.Foundation.json
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/Data/Controls.Foundation.json
@@ -25,6 +25,30 @@
             "Items":
             [
                 {
+                    "UniqueId": "Iconography",
+                    "Title": "Iconography",
+                    "Subtitle": "Segoe Fluent Icons and MDL2 Assets",
+                    "ImagePath": "ms-appx:///Assets/ControlIcons/DefaultIcon.png",
+                    "ImageIconPath": "ms-appx:///Assets/ControlIcons/DefaultIcon.png",
+                    "Description": "",
+                    "Content": "",
+                    "IncludedInBuild": true,
+                    "IsNew": false,
+                    "IsUpdated": false,
+                    "Docs":
+                    [
+                        {
+                            "Title": "Iconography in Windows 11",
+                            "Uri": "https://learn.microsoft.com/windows/apps/design/signature-experiences/iconography#system-icons"
+                        },
+                        {
+                            "Title": "Segoe Fluent Icons font",
+                            "Uri": "https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font"
+                        }
+                    ],
+                    "RelatedControls": []
+                },
+                {
                     "UniqueId": "Typography",
                     "Title": "Typography",
                     "Subtitle": "Typography type ramp and system fonts",

--- a/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/IconData.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/IconData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace iNKORE.UI.WPF.Modern.Gallery.DataModel;
+
+public class IconData
+{
+    public string Name { get; set; }
+    public string Code { get; set; }
+    public string[] Tags { get; set; } = Array.Empty<string>();
+    public bool IsSegoeFluentOnly { get; set; }
+
+    public string Character
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(Code)) return string.Empty;
+            try
+            {
+                int value = Convert.ToInt32(Code, 16);
+                return char.ConvertFromUtf32(value);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+    }
+
+    public string CodeGlyph => string.IsNullOrWhiteSpace(Code) ? string.Empty : "\\u" + Code;
+    public string TextGlyph => string.IsNullOrWhiteSpace(Code) ? string.Empty : "&#x" + Code + ";";
+
+    // WPF doesn't have Symbol enum like WinUI
+    public string SymbolName => null; 
+}

--- a/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/IconsData.json
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/IconsData.json
@@ -1,0 +1,14595 @@
+[
+  {
+    "Code": "E18A",
+    "Name": "Placeholder",
+    "Tags": [
+      "diamond",
+      "rhombus",
+      "shape",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E620",
+    "Name": "StopSlideShow",
+    "Tags": [
+      "images",
+      "presentation",
+      "gallery",
+      "photos",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E700",
+    "Name": "GlobalNavButton",
+    "Tags": [
+      "menu",
+      "hamburger",
+      "line",
+      "three",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E701",
+    "Name": "Wifi",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "E702",
+    "Name": "Bluetooth",
+    "Tags": [
+      "device",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E703",
+    "Name": "Connect",
+    "Tags": [
+      "device",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E704",
+    "Name": "InternetSharing",
+    "Tags": [
+      "network",
+      "wifi",
+      "connection",
+      "signal"
+    ]
+  },
+  {
+    "Code": "E705",
+    "Name": "VPN",
+    "Tags": [
+      "shield",
+      "privacy",
+      "security",
+      "lock",
+      "protection"
+    ]
+  },
+  {
+    "Code": "E706",
+    "Name": "Brightness",
+    "Tags": [
+      "sun",
+      "light",
+      "dark"
+    ]
+  },
+  {
+    "Code": "E707",
+    "Name": "MapPin",
+    "Tags": [
+      "location",
+      "marker",
+      "destination",
+      "place",
+      "position",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E708",
+    "Name": "QuietHours",
+    "Tags": [
+      "night",
+      "moon"
+    ]
+  },
+  {
+    "Code": "E709",
+    "Name": "Airplane",
+    "Tags": [
+      "flight",
+      "vehicle",
+      "travel"
+    ]
+  },
+  {
+    "Code": "E70A",
+    "Name": "Tablet",
+    "Tags": [
+      "device",
+      "screen",
+      "physical",
+      "watch",
+      "view",
+      "video",
+      "computer",
+      "pc"
+    ]
+  },
+  {
+    "Code": "E70B",
+    "Name": "QuickNote",
+    "Tags": [
+      "note",
+      "sticky note",
+      "sketch",
+      "reminder"
+    ]
+  },
+  {
+    "Code": "E70C",
+    "Name": "RememberedDevice",
+    "Tags": [
+      "device",
+      "memory",
+      "trusted",
+      "saved",
+      "access"
+    ]
+  },
+  {
+    "Code": "E70D",
+    "Name": "ChevronDown",
+    "Tags": [
+      "arrow",
+      "dropdown",
+      "direction",
+      "expand",
+      "contract"
+    ]
+  },
+  {
+    "Code": "E70E",
+    "Name": "ChevronUp",
+    "Tags": [
+      "arrow",
+      "dropdown",
+      "direction",
+      "expand",
+      "contract"
+    ]
+  },
+  {
+    "Code": "E70F",
+    "Name": "Edit",
+    "Tags": [
+      "pencil",
+      "update",
+      "create",
+      "draw",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E710",
+    "Name": "Add",
+    "Tags": [
+      "+",
+      "plus",
+      "addition",
+      "new",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E711",
+    "Name": "Cancel",
+    "Tags": [
+      "x",
+      "close",
+      "stop",
+      "exit",
+      "abort",
+      "reject",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E712",
+    "Name": "More",
+    "Tags": [
+      "...",
+      "dots",
+      "overflow",
+      "menu",
+      "navigation",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E713",
+    "Name": "Settings",
+    "Tags": [
+      "gear",
+      "options",
+      "cog",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E714",
+    "Name": "Video",
+    "Tags": [
+      "film",
+      "clip",
+      "media",
+      "content",
+      "camera",
+      "recording",
+      "capture",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E715",
+    "Name": "Mail",
+    "Tags": [
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "letter",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E716",
+    "Name": "People",
+    "Tags": [
+      "person",
+      "user",
+      "group",
+      "team",
+      "organization",
+      "contact",
+      "guest",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E717",
+    "Name": "Phone",
+    "Tags": [
+      "device",
+      "mobile",
+      "small screen",
+      "cellular telephone",
+      "apple",
+      "android",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E718",
+    "Name": "Pin",
+    "Tags": [
+      "save",
+      "share",
+      "post",
+      "favorite",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E719",
+    "Name": "Shop",
+    "Tags": [
+      "collection",
+      "purchase",
+      "retail",
+      "cart",
+      "online",
+      "currency",
+      "product",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E71A",
+    "Name": "Stop",
+    "Tags": [
+      "control",
+      "playback",
+      "start",
+      "begin",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E71B",
+    "Name": "Link",
+    "Tags": [
+      "link",
+      "share",
+      "web",
+      "internet",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E71C",
+    "Name": "Filter",
+    "Tags": [
+      "dropdown",
+      "sort",
+      "line",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E71D",
+    "Name": "AllApps",
+    "Tags": [
+      "plugin",
+      "square",
+      "stack",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E71E",
+    "Name": "Zoom",
+    "Tags": [
+      "zoom in",
+      "zoom out",
+      "magnifying glass",
+      "search",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E71F",
+    "Name": "ZoomOut",
+    "Tags": [
+      "zoom in",
+      "zoom out",
+      "magnifying glass",
+      "search",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E720",
+    "Name": "Microphone",
+    "Tags": [
+      "audio",
+      "voice",
+      "record",
+      "sound",
+      "speech",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E721",
+    "Name": "Search",
+    "Tags": [
+      "magnifying glass",
+      "zoom",
+      "inspect",
+      "review",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E722",
+    "Name": "Camera",
+    "Tags": [
+      "image",
+      "photography",
+      "picture",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E723",
+    "Name": "Attach",
+    "Tags": [
+      "image",
+      "photography",
+      "picture",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E724",
+    "Name": "Send",
+    "Tags": [
+      "paper plane",
+      "mail",
+      "message",
+      "email",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E725",
+    "Name": "SendFill",
+    "Tags": [
+      "paper plane",
+      "mail",
+      "message",
+      "email"
+    ]
+  },
+  {
+    "Code": "E726",
+    "Name": "WalkSolid",
+    "Tags": [
+      "person",
+      "user",
+      "movement",
+      "step",
+      "pedestrian",
+      "journey",
+      "foot"
+    ]
+  },
+  {
+    "Code": "E727",
+    "Name": "InPrivate",
+    "Tags": [
+      "private",
+      "mode",
+      "browser",
+      "person"
+    ]
+  },
+  {
+    "Code": "E728",
+    "Name": "FavoriteList",
+    "Tags": [
+      "star",
+      "like"
+    ]
+  },
+  {
+    "Code": "E729",
+    "Name": "PageSolid",
+    "Tags": [
+      "document",
+      "file",
+      "sheet",
+      "paper",
+      "text",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E72A",
+    "Name": "Forward",
+    "Tags": [
+      "arrow",
+      "next",
+      "send",
+      "right",
+      "proceed",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E72B",
+    "Name": "Back",
+    "Tags": [
+      "arrow",
+      "previous",
+      "return",
+      "left",
+      "rewind",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E72C",
+    "Name": "Refresh",
+    "Tags": [
+      "reload",
+      "update",
+      "restart",
+      "circle",
+      "sync",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E72D",
+    "Name": "Share",
+    "Tags": [
+      "arrow",
+      "square",
+      "forward",
+      "right",
+      "send",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E72E",
+    "Name": "Lock",
+    "Tags": [
+      "private",
+      "security",
+      "access",
+      "protected",
+      "safety",
+      "permission",
+      "access",
+      "protection"
+    ]
+  },
+  {
+    "Code": "E72F",
+    "Name": "BlockedSite",
+    "Tags": [
+      "private",
+      "security",
+      "access",
+      "protected",
+      "safety",
+      "permission",
+      "access",
+      "protection"
+    ],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "E730",
+    "Name": "ReportHacked",
+    "Tags": [
+      "!",
+      "security",
+      "alert",
+      "breach",
+      "shield",
+      "warning",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E731",
+    "Name": "EMI",
+    "Tags": [
+      "company",
+      "building",
+      "office",
+      "enterprise",
+      "corporate",
+      "business"
+    ]
+  },
+  {
+    "Code": "E733",
+    "Name": "Blocked",
+    "Tags": []
+  },
+  {
+    "Code": "E734",
+    "Name": "FavoriteStar",
+    "Tags": [
+      "star",
+      "favorite",
+      "highlight",
+      "bookmark",
+      "like",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E735",
+    "Name": "FavoriteStarFill",
+    "Tags": [
+      "star",
+      "favorite",
+      "highlight",
+      "bookmark",
+      "like",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E736",
+    "Name": "ReadingMode",
+    "Tags": [
+      "read",
+      "list",
+      "content",
+      "collection",
+      "news"
+    ]
+  },
+  {
+    "Code": "E737",
+    "Name": "Favicon",
+    "Tags": [
+      "logo",
+      "icon",
+      "brand",
+      "shortcut",
+      "symbol"
+    ]
+  },
+  {
+    "Code": "E738",
+    "Name": "Remove",
+    "Tags": [
+      "-",
+      "delete",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E739",
+    "Name": "Checkbox",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "E73A",
+    "Name": "CheckboxComposite",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "E73B",
+    "Name": "CheckboxFill",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "E73C",
+    "Name": "CheckboxIndeterminate",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "E73D",
+    "Name": "CheckboxCompositeReversed",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "E73E",
+    "Name": "CheckMark",
+    "Tags": [
+      "approval",
+      "selected"
+    ]
+  },
+  {
+    "Code": "E73F",
+    "Name": "BackToWindow",
+    "Tags": [
+      "arrow",
+      "restore",
+      "window",
+      "return",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E740",
+    "Name": "FullScreen",
+    "Tags": [
+      "arrow",
+      "expand",
+      "maximize",
+      "view",
+      "screen",
+      "zoom",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E741",
+    "Name": "ResizeTouchLarger",
+    "Tags": [
+      "arrow",
+      "expand",
+      "grow",
+      "touch",
+      "increase",
+      "size"
+    ]
+  },
+  {
+    "Code": "E742",
+    "Name": "ResizeTouchSmaller",
+    "Tags": [
+      "arrow",
+      "shrink",
+      "reduce",
+      "decrease",
+      "minimize",
+      "touch"
+    ]
+  },
+  {
+    "Code": "E743",
+    "Name": "ResizeMouseSmall",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E744",
+    "Name": "ResizeMouseMedium",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E745",
+    "Name": "ResizeMouseWide",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E746",
+    "Name": "ResizeMouseTall",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E747",
+    "Name": "ResizeMouseLarge",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E748",
+    "Name": "SwitchUser",
+    "Tags": [
+      "person",
+      "user",
+      "switch",
+      "profile",
+      "account",
+      "login"
+    ]
+  },
+  {
+    "Code": "E749",
+    "Name": "Print",
+    "Tags": [
+      "printer",
+      "paper",
+      "copy",
+      "fax",
+      "office",
+      "ink",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E74A",
+    "Name": "Up",
+    "Tags": [
+      "arrow",
+      "increase",
+      "rise",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E74B",
+    "Name": "Down",
+    "Tags": [
+      "arrow",
+      "decrease",
+      "drop"
+    ]
+  },
+  {
+    "Code": "E74C",
+    "Name": "OEM",
+    "Tags": [
+      "brand",
+      "manufacturer",
+      "original"
+    ]
+  },
+  {
+    "Code": "E74D",
+    "Name": "Delete",
+    "Tags": [
+      "bin",
+      "trash",
+      "can",
+      "remove",
+      "edit",
+      "byee",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E74E",
+    "Name": "Save",
+    "Tags": [
+      "floppy",
+      "disk",
+      "device",
+      "old",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E74F",
+    "Name": "Mute",
+    "Tags": [
+      "sound",
+      "silence",
+      "volume",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E750",
+    "Name": "BackSpaceQWERTY",
+    "Tags": [
+      "delete",
+      "backward",
+      "remove",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E751",
+    "Name": "ReturnKey",
+    "Tags": [
+      "arrow",
+      "enter",
+      "submit",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E752",
+    "Name": "UpArrowShiftKey",
+    "Tags": [
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E753",
+    "Name": "Cloud",
+    "Tags": [
+      "storage",
+      "upload",
+      "download",
+      "save",
+      "sync",
+      "remote"
+    ]
+  },
+  {
+    "Code": "E754",
+    "Name": "Flashlight",
+    "Tags": [
+      "torch",
+      "lamp"
+    ]
+  },
+  {
+    "Code": "E755",
+    "Name": "RotationLock",
+    "Tags": [
+      "arrow",
+      "security",
+      "access",
+      "protected",
+      "safety",
+      "permission",
+      "access",
+      "protection"
+    ]
+  },
+  {
+    "Code": "E756",
+    "Name": "CommandPrompt",
+    "Tags": [
+      "terminal",
+      "console",
+      "cmd"
+    ]
+  },
+  {
+    "Code": "E759",
+    "Name": "SIPMove",
+    "Tags": []
+  },
+  {
+    "Code": "E75A",
+    "Name": "SIPUndock",
+    "Tags": []
+  },
+  {
+    "Code": "E75B",
+    "Name": "SIPRedock",
+    "Tags": []
+  },
+  {
+    "Code": "E75C",
+    "Name": "EraseTool",
+    "Tags": [
+      "undo",
+      "remove",
+      "delete"
+    ]
+  },
+  {
+    "Code": "E75D",
+    "Name": "UnderscoreSpace",
+    "Tags": [
+      "separation"
+    ]
+  },
+  {
+    "Code": "E75E",
+    "Name": "GripperTool",
+    "Tags": [
+      "drag",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E75F",
+    "Name": "Dialpad",
+    "Tags": [
+      "dots",
+      "phone",
+      "call",
+      "number"
+    ]
+  },
+  {
+    "Code": "E760",
+    "Name": "PageLeft",
+    "Tags": [
+      "arrow",
+      "previous",
+      "back"
+    ]
+  },
+  {
+    "Code": "E761",
+    "Name": "PageRight",
+    "Tags": [
+      "arrow",
+      "next",
+      "forward"
+    ]
+  },
+  {
+    "Code": "E762",
+    "Name": "MultiSelect",
+    "Tags": [
+      "checkmark",
+      "task",
+      "list",
+      "type"
+    ]
+  },
+  {
+    "Code": "E763",
+    "Name": "KeyboardLeftHanded",
+    "Tags": [
+      "keyboard",
+      "type",
+      "key",
+      "device"
+    ]
+  },
+  {
+    "Code": "E764",
+    "Name": "KeyboardRightHanded",
+    "Tags": [
+      "keyboard",
+      "type",
+      "key",
+      "device"
+    ]
+  },
+  {
+    "Code": "E765",
+    "Name": "KeyboardClassic",
+    "Tags": [
+      "keyboard",
+      "type",
+      "key",
+      "device",
+      "digital",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E766",
+    "Name": "KeyboardSplit",
+    "Tags": [
+      "keyboard",
+      "type",
+      "key",
+      "device"
+    ]
+  },
+  {
+    "Code": "E767",
+    "Name": "Volume",
+    "Tags": [
+      "sound",
+      "audio",
+      "level",
+      "speaker",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E768",
+    "Name": "Play",
+    "Tags": [
+      "control",
+      "playback",
+      "start",
+      "begin",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E769",
+    "Name": "Pause",
+    "Tags": [
+      "control",
+      "playback",
+      "freeze",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E76B",
+    "Name": "ChevronLeft",
+    "Tags": [
+      "arrow",
+      "dropdown",
+      "direction",
+      "expand",
+      "contract"
+    ]
+  },
+  {
+    "Code": "E76C",
+    "Name": "ChevronRight",
+    "Tags": [
+      "arrow",
+      "dropdown",
+      "direction",
+      "expand",
+      "contract"
+    ]
+  },
+  {
+    "Code": "E76D",
+    "Name": "InkingTool",
+    "Tags": [
+      "pen",
+      "edit",
+      "create",
+      "draw"
+    ]
+  },
+  {
+    "Code": "E76E",
+    "Name": "Emoji2",
+    "Tags": [
+      "face",
+      "smiley",
+      "emote",
+      "feeling",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E76F",
+    "Name": "GripperBarHorizontal",
+    "Tags": [
+      "drag",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E770",
+    "Name": "System",
+    "Tags": [
+      "rectangle",
+      "shape"
+    ]
+  },
+  {
+    "Code": "E771",
+    "Name": "Personalize",
+    "Tags": [
+      "brush",
+      "customize"
+    ]
+  },
+  {
+    "Code": "E772",
+    "Name": "Devices",
+    "Tags": [
+      "hardware",
+      "connections",
+      "peripherals",
+      "electronics",
+      "gadgets"
+    ]
+  },
+  {
+    "Code": "E773",
+    "Name": "SearchAndApps",
+    "Tags": [
+      "magnifying glass",
+      "zoom",
+      "inspect",
+      "review"
+    ]
+  },
+  {
+    "Code": "E774",
+    "Name": "Globe",
+    "Tags": [
+      "web",
+      "world",
+      "earth",
+      "global",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E775",
+    "Name": "TimeLanguage",
+    "Tags": [
+      "clock",
+      "region"
+    ]
+  },
+  {
+    "Code": "E776",
+    "Name": "EaseOfAccess",
+    "Tags": [
+      "person",
+      "inclusive"
+    ]
+  },
+  {
+    "Code": "E777",
+    "Name": "UpdateRestore",
+    "Tags": [
+      "arrow",
+      "refresh",
+      "recover",
+      "repair"
+    ]
+  },
+  {
+    "Code": "E778",
+    "Name": "HangUp",
+    "Tags": [
+      "phone",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E779",
+    "Name": "ContactInfo",
+    "Tags": [
+      "person",
+      "user",
+      "details",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E77A",
+    "Name": "Unpin",
+    "Tags": [
+      "remove",
+      "delete",
+      "unattach",
+      "clear",
+      "disengage",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E77B",
+    "Name": "Contact",
+    "Tags": [
+      "person",
+      "user",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E77C",
+    "Name": "Memo",
+    "Tags": [
+      "voicemail",
+      "tape",
+      "playback",
+      "audio",
+      "recording",
+      "message",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E77E",
+    "Name": "IncomingCall",
+    "Tags": [
+      "phone",
+      "receive"
+    ]
+  },
+  {
+    "Code": "E77F",
+    "Name": "Paste",
+    "Tags": [
+      "clipboard",
+      "copy",
+      "memory",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E780",
+    "Name": "PhoneBook",
+    "Tags": [
+      "contacts",
+      "directory",
+      "list",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E781",
+    "Name": "LEDLight",
+    "Tags": [
+      "light",
+      "illuminate"
+    ]
+  },
+  {
+    "Code": "E783",
+    "Name": "Error",
+    "Tags": [
+      "!",
+      "exclamation",
+      "alert"
+    ]
+  },
+  {
+    "Code": "E784",
+    "Name": "GripperBarVertical",
+    "Tags": [
+      "drag",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E785",
+    "Name": "Unlock",
+    "Tags": [
+      "security",
+      "access",
+      "protected",
+      "safety",
+      "permission",
+      "access",
+      "protection"
+    ]
+  },
+  {
+    "Code": "E786",
+    "Name": "Slideshow",
+    "Tags": [
+      "images",
+      "presentation",
+      "gallery",
+      "photos",
+      "show",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E787",
+    "Name": "Calendar",
+    "Tags": [
+      "time",
+      "date",
+      "planning",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E788",
+    "Name": "GripperResize",
+    "Tags": [
+      "triangle",
+      "drag",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E789",
+    "Name": "Megaphone",
+    "Tags": [
+      "announcement",
+      "shout"
+    ]
+  },
+  {
+    "Code": "E78A",
+    "Name": "Trim",
+    "Tags": [
+      "cut",
+      "edit",
+      "shorten",
+      "clip",
+      "crop",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E78B",
+    "Name": "NewWindow",
+    "Tags": [
+      "open",
+      "launch",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E78C",
+    "Name": "SaveLocal",
+    "Tags": [
+      "floppy",
+      "disk",
+      "device",
+      "old",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E790",
+    "Name": "Color",
+    "Tags": [
+      "theme",
+      "palette",
+      "art",
+      "edit",
+      "paint"
+    ]
+  },
+  {
+    "Code": "E791",
+    "Name": "DataSense",
+    "Tags": [
+      "bars"
+    ]
+  },
+  {
+    "Code": "E792",
+    "Name": "SaveAs",
+    "Tags": [
+      "floppy",
+      "disk",
+      "device",
+      "old"
+    ]
+  },
+  {
+    "Code": "E793",
+    "Name": "Light",
+    "Tags": [
+      "brightness",
+      "sun",
+      "dark",
+      "theme",
+      "toggle"
+    ]
+  },
+  {
+    "Code": "E794",
+    "Name": "Effects",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "E799",
+    "Name": "AspectRatio",
+    "Tags": []
+  },
+  {
+    "Code": "E7A1",
+    "Name": "Contrast",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "E7A5",
+    "Name": "DataSenseBar",
+    "Tags": [
+      "bars"
+    ]
+  },
+  {
+    "Code": "E7A6",
+    "Name": "Redo",
+    "Tags": [
+      "arrow",
+      "restore",
+      "forward",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7A7",
+    "Name": "Undo",
+    "Tags": [
+      "arrow",
+      "revert",
+      "back",
+      "cancel",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7A8",
+    "Name": "Crop",
+    "Tags": [
+      "cut",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7AA",
+    "Name": "PhotoCollection",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "E7AC",
+    "Name": "OpenWith",
+    "Tags": [
+      "application",
+      "program",
+      "associate",
+      "file",
+      "choose",
+      "viewer",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7AD",
+    "Name": "Rotate",
+    "Tags": [
+      "arrow",
+      "edit",
+      "create",
+      "canvas",
+      "horizontal",
+      "vertical",
+      "flip",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7B3",
+    "Name": "RedEye",
+    "Tags": [
+      "blink",
+      "pupil",
+      "show",
+      "hide",
+      "password"
+    ]
+  },
+  {
+    "Code": "E7B5",
+    "Name": "SetlockScreen",
+    "Tags": [
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7B7",
+    "Name": "MapPin2",
+    "Tags": [
+      "location",
+      "marker",
+      "destination",
+      "place",
+      "position",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7B8",
+    "Name": "Package",
+    "Tags": [
+      "archive",
+      "bundle",
+      "file",
+      "collection",
+      "install"
+    ]
+  },
+  {
+    "Code": "E7BA",
+    "Name": "Warning",
+    "Tags": [
+      "!",
+      "alert",
+      "exclamation",
+      "triangle",
+      "issue"
+    ]
+  },
+  {
+    "Code": "E7BC",
+    "Name": "ReadingList",
+    "Tags": [
+      "read",
+      "list",
+      "content",
+      "collection",
+      "news"
+    ]
+  },
+  {
+    "Code": "E7BE",
+    "Name": "Education",
+    "Tags": [
+      "learning",
+      "knowledge",
+      "school",
+      "study",
+      "college",
+      "university",
+      "graduation"
+    ]
+  },
+  {
+    "Code": "E7BF",
+    "Name": "ShoppingCart",
+    "Tags": [
+      "collection",
+      "purchase",
+      "retail",
+      "online",
+      "currency",
+      "product"
+    ]
+  },
+  {
+    "Code": "E7C0",
+    "Name": "Train",
+    "Tags": [
+      "rail",
+      "transport",
+      "travel",
+      "track",
+      "station"
+    ]
+  },
+  {
+    "Code": "E7C1",
+    "Name": "Flag",
+    "Tags": [
+      "urgent",
+      "important",
+      "look",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7C2",
+    "Name": "Move",
+    "Tags": [
+      "arrow",
+      "drag",
+      "handle"
+    ]
+  },
+  {
+    "Code": "E7C3",
+    "Name": "Page",
+    "Tags": [
+      "document",
+      "file",
+      "sheet",
+      "paper",
+      "text",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7C4",
+    "Name": "TaskView",
+    "Tags": [
+      "document",
+      "file",
+      "sheet",
+      "paper",
+      "text"
+    ]
+  },
+  {
+    "Code": "E7C5",
+    "Name": "BrowsePhotos",
+    "Tags": [
+      "magnifying glass",
+      "zoom",
+      "inspect",
+      "review",
+      "gallery",
+      "images",
+      "pictures",
+      "search",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7C6",
+    "Name": "HalfStarLeft",
+    "Tags": [
+      "rating",
+      "score"
+    ]
+  },
+  {
+    "Code": "E7C7",
+    "Name": "HalfStarRight",
+    "Tags": [
+      "rating",
+      "score"
+    ]
+  },
+  {
+    "Code": "E7C8",
+    "Name": "Record",
+    "Tags": [
+      "circle",
+      "control",
+      "playback",
+      "wait",
+      "stop",
+      "transcribe"
+    ]
+  },
+  {
+    "Code": "E7C9",
+    "Name": "TouchPointer",
+    "Tags": [
+      "arrow",
+      "interact",
+      "click",
+      "hand",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7DE",
+    "Name": "LangJPN",
+    "Tags": [
+      "language",
+      "kanji",
+      "japan"
+    ]
+  },
+  {
+    "Code": "E7E3",
+    "Name": "Ferry",
+    "Tags": [
+      "boat",
+      "ship",
+      "ocean",
+      "travel"
+    ]
+  },
+  {
+    "Code": "E7E6",
+    "Name": "Highlight",
+    "Tags": [
+      "marker",
+      "edit",
+      "draw",
+      "focus",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7E7",
+    "Name": "ActionCenterNotification",
+    "Tags": [
+      "message",
+      "alert",
+      "reminder",
+      "warning",
+      "update"
+    ]
+  },
+  {
+    "Code": "E7E8",
+    "Name": "PowerButton",
+    "Tags": [
+      "on",
+      "off"
+    ]
+  },
+  {
+    "Code": "E7EA",
+    "Name": "ResizeTouchNarrower",
+    "Tags": [
+      "arrow"
+    ]
+  },
+  {
+    "Code": "E7EB",
+    "Name": "ResizeTouchShorter",
+    "Tags": [
+      "arrow"
+    ]
+  },
+  {
+    "Code": "E7EC",
+    "Name": "DrivingMode",
+    "Tags": [
+      "car"
+    ]
+  },
+  {
+    "Code": "E7ED",
+    "Name": "RingerSilent",
+    "Tags": [
+      "bell",
+      "sound",
+      "mute",
+      "volume"
+    ]
+  },
+  {
+    "Code": "E7EE",
+    "Name": "OtherUser",
+    "Tags": [
+      "person",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7EF",
+    "Name": "Admin",
+    "Tags": [
+      "elevated",
+      "permissions",
+      "control",
+      "rights",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7F0",
+    "Name": "CC",
+    "Tags": [
+      "subtitles",
+      "text",
+      "caption",
+      "speech",
+      "accessibility",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E7F1",
+    "Name": "SDCard",
+    "Tags": [
+      "storage",
+      "memory",
+      "external",
+      "device"
+    ]
+  },
+  {
+    "Code": "E7F2",
+    "Name": "CallForwarding",
+    "Tags": [
+      "phone",
+      "handset",
+      "audio"
+    ]
+  },
+  {
+    "Code": "E7F3",
+    "Name": "SettingsDisplaySound",
+    "Tags": [
+      "volume",
+      "sound",
+      "audio",
+      "device",
+      "wave"
+    ]
+  },
+  {
+    "Code": "E7F4",
+    "Name": "TVMonitor",
+    "Tags": [
+      "screen",
+      "display",
+      "television",
+      "view"
+    ]
+  },
+  {
+    "Code": "E7F5",
+    "Name": "Speakers",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume"
+    ]
+  },
+  {
+    "Code": "E7F6",
+    "Name": "Headphone",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume",
+      "device"
+    ]
+  },
+  {
+    "Code": "E7F7",
+    "Name": "DeviceLaptopPic",
+    "Tags": [
+      "projection",
+      "present",
+      "presentation",
+      "view",
+      "slide",
+      "lecture"
+    ]
+  },
+  {
+    "Code": "E7F8",
+    "Name": "DeviceLaptopNoPic",
+    "Tags": [
+      "projection",
+      "present",
+      "presentation",
+      "view",
+      "slide",
+      "lecture"
+    ]
+  },
+  {
+    "Code": "E7F9",
+    "Name": "DeviceMonitorRightPic",
+    "Tags": [
+      "projection",
+      "present",
+      "presentation",
+      "view",
+      "slide",
+      "lecture"
+    ]
+  },
+  {
+    "Code": "E7FA",
+    "Name": "DeviceMonitorLeftPic",
+    "Tags": [
+      "projection",
+      "present",
+      "presentation",
+      "view",
+      "slide",
+      "lecture"
+    ]
+  },
+  {
+    "Code": "E7FB",
+    "Name": "DeviceMonitorNoPic",
+    "Tags": [
+      "projection",
+      "present",
+      "presentation",
+      "view",
+      "slide",
+      "lecture"
+    ]
+  },
+  {
+    "Code": "E7FC",
+    "Name": "Game",
+    "Tags": [
+      "videogame",
+      "controller"
+    ]
+  },
+  {
+    "Code": "E7FD",
+    "Name": "HorizontalTabKey",
+    "Tags": [
+      "arrow",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E802",
+    "Name": "StreetsideSplitMinimize",
+    "Tags": [
+      "view",
+      "map"
+    ]
+  },
+  {
+    "Code": "E803",
+    "Name": "StreetsideSplitExpand",
+    "Tags": [
+      "view",
+      "map"
+    ]
+  },
+  {
+    "Code": "E804",
+    "Name": "Car",
+    "Tags": [
+      "vehicle",
+      "transportation",
+      "drive",
+      "automobile",
+      "road"
+    ]
+  },
+  {
+    "Code": "E805",
+    "Name": "Walk",
+    "Tags": [
+      "person",
+      "user",
+      "movement",
+      "step",
+      "pedestrian",
+      "journey",
+      "foot"
+    ]
+  },
+  {
+    "Code": "E806",
+    "Name": "Bus",
+    "Tags": [
+      "vehicle",
+      "transportation",
+      "public",
+      "travel"
+    ]
+  },
+  {
+    "Code": "E809",
+    "Name": "TiltUp",
+    "Tags": [
+      "angle",
+      "rotate",
+      "elevation"
+    ]
+  },
+  {
+    "Code": "E80A",
+    "Name": "TiltDown",
+    "Tags": [
+      "angle",
+      "rotate",
+      "elevation"
+    ]
+  },
+  {
+    "Code": "E80B",
+    "Name": "CallControl",
+    "Tags": [
+      "phone",
+      "handset",
+      "audio"
+    ]
+  },
+  {
+    "Code": "E80C",
+    "Name": "RotateMapRight",
+    "Tags": [
+      "arrow",
+      "edit",
+      "create",
+      "canvas",
+      "horizontal",
+      "vertical",
+      "travel",
+      "navigation",
+      "flip"
+    ]
+  },
+  {
+    "Code": "E80D",
+    "Name": "RotateMapLeft",
+    "Tags": [
+      "arrow",
+      "edit",
+      "create",
+      "canvas",
+      "horizontal",
+      "vertical",
+      "travel",
+      "navigation",
+      "flip"
+    ]
+  },
+  {
+    "Code": "E80F",
+    "Name": "Home",
+    "Tags": [
+      "house",
+      "safety",
+      "location",
+      "space",
+      "wfh",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E811",
+    "Name": "ParkingLocation",
+    "Tags": [
+      "car",
+      "spot",
+      "space"
+    ]
+  },
+  {
+    "Code": "E812",
+    "Name": "MapCompassTop",
+    "Tags": [
+      "triangle",
+      "up"
+    ]
+  },
+  {
+    "Code": "E813",
+    "Name": "MapCompassBottom",
+    "Tags": [
+      "triangle",
+      "down"
+    ]
+  },
+  {
+    "Code": "E814",
+    "Name": "IncidentTriangle",
+    "Tags": [
+      "!",
+      "error",
+      "warning",
+      "alert",
+      "exclamation",
+      "issue"
+    ]
+  },
+  {
+    "Code": "E815",
+    "Name": "Touch",
+    "Tags": [
+      "finger",
+      "tap",
+      "gesture",
+      "screen",
+      "touchscreen"
+    ]
+  },
+  {
+    "Code": "E816",
+    "Name": "MapDirections",
+    "Tags": [
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E819",
+    "Name": "StartPoint",
+    "Tags": [
+      "map",
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E81A",
+    "Name": "StopPoint",
+    "Tags": [
+      "map",
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E81B",
+    "Name": "EndPoint",
+    "Tags": [
+      "flag",
+      "map",
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E81C",
+    "Name": "History",
+    "Tags": [
+      "clock",
+      "time",
+      "arrow",
+      "back",
+      "undo"
+    ]
+  },
+  {
+    "Code": "E81D",
+    "Name": "Location",
+    "Tags": [
+      "pin",
+      "marker",
+      "map",
+      "travel"
+    ]
+  },
+  {
+    "Code": "E81E",
+    "Name": "MapLayers",
+    "Tags": [
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E81F",
+    "Name": "Accident",
+    "Tags": [
+      "car"
+    ]
+  },
+  {
+    "Code": "E821",
+    "Name": "Work",
+    "Tags": [
+      "bag",
+      "handbag",
+      "briefcase",
+      "office"
+    ]
+  },
+  {
+    "Code": "E822",
+    "Name": "Construction",
+    "Tags": [
+      "person",
+      "user",
+      "work"
+    ]
+  },
+  {
+    "Code": "E823",
+    "Name": "Recent",
+    "Tags": [
+      "clock",
+      "time",
+      "history",
+      "latest",
+      "new",
+      "update",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E825",
+    "Name": "Bank",
+    "Tags": [
+      "finance",
+      "money",
+      "account",
+      "deposit",
+      "institution"
+    ]
+  },
+  {
+    "Code": "E826",
+    "Name": "DownloadMap",
+    "Tags": [
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E829",
+    "Name": "InkingToolFill2",
+    "Tags": [
+      "draw",
+      "paint",
+      "sketch"
+    ]
+  },
+  {
+    "Code": "E82A",
+    "Name": "HighlightFill2",
+    "Tags": [
+      "marker",
+      "edit",
+      "draw",
+      "focus"
+    ]
+  },
+  {
+    "Code": "E82B",
+    "Name": "EraseToolFill",
+    "Tags": [
+      "undo",
+      "remove",
+      "delete"
+    ]
+  },
+  {
+    "Code": "E82C",
+    "Name": "EraseToolFill2",
+    "Tags": [
+      "undo",
+      "remove",
+      "delete"
+    ]
+  },
+  {
+    "Code": "E82D",
+    "Name": "Dictionary",
+    "Tags": [
+      "book",
+      "reference"
+    ]
+  },
+  {
+    "Code": "E82E",
+    "Name": "DictionaryAdd",
+    "Tags": [
+      "+",
+      "plus",
+      "book",
+      "reference"
+    ]
+  },
+  {
+    "Code": "E82F",
+    "Name": "ToolTip",
+    "Tags": [
+      "light",
+      "lightbulb",
+      "light",
+      "illuminate",
+      "knowledge",
+      "smart",
+      "idea"
+    ]
+  },
+  {
+    "Code": "E830",
+    "Name": "ChromeBack",
+    "Tags": [
+      "arrow",
+      "back",
+      "navigate",
+      "browser"
+    ]
+  },
+  {
+    "Code": "E835",
+    "Name": "ProvisioningPackage",
+    "Tags": [
+      "configuration",
+      "settings"
+    ]
+  },
+  {
+    "Code": "E836",
+    "Name": "AddRemoteDevice",
+    "Tags": [
+      "connect",
+      "remote",
+      "pair"
+    ]
+  },
+  {
+    "Code": "E838",
+    "Name": "FolderOpen",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "E839",
+    "Name": "Ethernet",
+    "Tags": [
+      "cable",
+      "network",
+      "connection",
+      "wired",
+      "internet"
+    ]
+  },
+  {
+    "Code": "E83A",
+    "Name": "ShareBroadband",
+    "Tags": [
+      "arrow"
+    ]
+  },
+  {
+    "Code": "E83B",
+    "Name": "DirectAccess",
+    "Tags": []
+  },
+  {
+    "Code": "E83C",
+    "Name": "DialUp",
+    "Tags": [
+      "phone",
+      "call",
+      "number"
+    ]
+  },
+  {
+    "Code": "E83D",
+    "Name": "DefenderApp",
+    "Tags": [
+      "shield",
+      "security",
+      "protection",
+      "safety"
+    ]
+  },
+  {
+    "Code": "E83E",
+    "Name": "BatteryCharging9",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E83F",
+    "Name": "Battery10",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E840",
+    "Name": "Pinned",
+    "Tags": [
+      "save",
+      "share",
+      "post",
+      "favorite"
+    ]
+  },
+  {
+    "Code": "E841",
+    "Name": "PinFill",
+    "Tags": [
+      "save",
+      "share",
+      "post",
+      "favorite"
+    ]
+  },
+  {
+    "Code": "E842",
+    "Name": "PinnedFill",
+    "Tags": [
+      "save",
+      "share",
+      "post",
+      "favorite"
+    ]
+  },
+  {
+    "Code": "E843",
+    "Name": "PeriodKey",
+    "Tags": [
+      "dot",
+      "keyboard",
+      "punctuation"
+    ]
+  },
+  {
+    "Code": "E844",
+    "Name": "PuncKey",
+    "Tags": [
+      "symbol",
+      "keyboard",
+      "punctuation"
+    ]
+  },
+  {
+    "Code": "E845",
+    "Name": "RevToggleKey",
+    "Tags": [
+      "arrow",
+      "reverse",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E846",
+    "Name": "RightArrowKeyTime1",
+    "Tags": [
+      "navigate",
+      "forward",
+      "progress"
+    ]
+  },
+  {
+    "Code": "E847",
+    "Name": "RightArrowKeyTime2",
+    "Tags": [
+      "navigate",
+      "forward",
+      "progress"
+    ]
+  },
+  {
+    "Code": "E848",
+    "Name": "LeftQuote",
+    "Tags": [
+      "opening",
+      "text",
+      "symbol",
+      "mark"
+    ]
+  },
+  {
+    "Code": "E849",
+    "Name": "RightQuote",
+    "Tags": [
+      "ending",
+      "text",
+      "symbol",
+      "mark"
+    ]
+  },
+  {
+    "Code": "E84A",
+    "Name": "DownShiftKey",
+    "Tags": [
+      "abc",
+      "lowercase"
+    ]
+  },
+  {
+    "Code": "E84B",
+    "Name": "UpShiftKey",
+    "Tags": [
+      "abc",
+      "uppercase"
+    ]
+  },
+  {
+    "Code": "E84C",
+    "Name": "PuncKey0",
+    "Tags": [
+      "symbol",
+      "keyboard",
+      "punctuation"
+    ]
+  },
+  {
+    "Code": "E84D",
+    "Name": "PuncKeyLeftBottom",
+    "Tags": [
+      "symbol",
+      "keyboard",
+      "punctuation"
+    ]
+  },
+  {
+    "Code": "E84E",
+    "Name": "RightArrowKeyTime3",
+    "Tags": [
+      "navigate",
+      "forward",
+      "progress"
+    ]
+  },
+  {
+    "Code": "E84F",
+    "Name": "RightArrowKeyTime4",
+    "Tags": [
+      "navigate",
+      "forward",
+      "progress"
+    ]
+  },
+  {
+    "Code": "E850",
+    "Name": "Battery0",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E851",
+    "Name": "Battery1",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E852",
+    "Name": "Battery2",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E853",
+    "Name": "Battery3",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E854",
+    "Name": "Battery4",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E855",
+    "Name": "Battery5",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E856",
+    "Name": "Battery6",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E857",
+    "Name": "Battery7",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E858",
+    "Name": "Battery8",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E859",
+    "Name": "Battery9",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "E85A",
+    "Name": "BatteryCharging0",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E85B",
+    "Name": "BatteryCharging1",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E85C",
+    "Name": "BatteryCharging2",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E85D",
+    "Name": "BatteryCharging3",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E85E",
+    "Name": "BatteryCharging4",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E85F",
+    "Name": "BatteryCharging5",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E860",
+    "Name": "BatteryCharging6",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E861",
+    "Name": "BatteryCharging7",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E862",
+    "Name": "BatteryCharging8",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "E863",
+    "Name": "BatterySaver0",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E864",
+    "Name": "BatterySaver1",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E865",
+    "Name": "BatterySaver2",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E866",
+    "Name": "BatterySaver3",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E867",
+    "Name": "BatterySaver4",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E868",
+    "Name": "BatterySaver5",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E869",
+    "Name": "BatterySaver6",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E86A",
+    "Name": "BatterySaver7",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E86B",
+    "Name": "BatterySaver8",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "E86C",
+    "Name": "SignalBars1",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E86D",
+    "Name": "SignalBars2",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E86E",
+    "Name": "SignalBars3",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E86F",
+    "Name": "SignalBars4",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E870",
+    "Name": "SignalBars5",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E871",
+    "Name": "SignalNotConnected",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E872",
+    "Name": "Wifi1",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "E873",
+    "Name": "Wifi2",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "E874",
+    "Name": "Wifi3",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "E875",
+    "Name": "MobSIMLock",
+    "Tags": [
+      "security",
+      "phone",
+      "restricted"
+    ]
+  },
+  {
+    "Code": "E876",
+    "Name": "MobSIMMissing",
+    "Tags": [
+      "error",
+      "phone",
+      "absent"
+    ]
+  },
+  {
+    "Code": "E877",
+    "Name": "Vibrate",
+    "Tags": [
+      "phone",
+      "notification",
+      "alert",
+      "silent",
+      "alert"
+    ]
+  },
+  {
+    "Code": "E878",
+    "Name": "RoamingInternational",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "E879",
+    "Name": "RoamingDomestic",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "E87A",
+    "Name": "CallForwardInternational",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "E87B",
+    "Name": "CallForwardRoaming",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "E87C",
+    "Name": "JpnRomanji",
+    "Tags": [
+      "english",
+      "Japanese",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E87D",
+    "Name": "JpnRomanjiLock",
+    "Tags": [
+      "english",
+      "Japanese",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E87E",
+    "Name": "JpnRomanjiShift",
+    "Tags": [
+      "english",
+      "Japanese",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E87F",
+    "Name": "JpnRomanjiShiftLock",
+    "Tags": [
+      "Japanese",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E880",
+    "Name": "StatusDataTransfer",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E881",
+    "Name": "StatusDataTransferVPN",
+    "Tags": [
+      "secure",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E882",
+    "Name": "StatusDualSIM2",
+    "Tags": [
+      "number",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "E883",
+    "Name": "StatusDualSIM2VPN",
+    "Tags": [
+      "secure",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E884",
+    "Name": "StatusDualSIM1",
+    "Tags": [
+      "number",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E885",
+    "Name": "StatusDualSIM1VPN",
+    "Tags": [
+      "secure",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E886",
+    "Name": "StatusSGLTE",
+    "Tags": [
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E887",
+    "Name": "StatusSGLTECell",
+    "Tags": [
+      "phone",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E888",
+    "Name": "StatusSGLTEDataVPN",
+    "Tags": [
+      "secure",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E889",
+    "Name": "StatusVPN",
+    "Tags": [
+      "lock",
+      "secure",
+      "network",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E88A",
+    "Name": "WifiHotspot",
+    "Tags": [
+      "connection",
+      "network",
+      "share",
+      "network"
+    ]
+  },
+  {
+    "Code": "E88B",
+    "Name": "LanguageKor",
+    "Tags": [
+      "korean",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E88C",
+    "Name": "LanguageCht",
+    "Tags": [
+      "chinese",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E88D",
+    "Name": "LanguageChs",
+    "Tags": [
+      "chinese",
+      "transliteration",
+      "alphabet",
+      "language"
+    ]
+  },
+  {
+    "Code": "E88E",
+    "Name": "USB",
+    "Tags": [
+      "device",
+      "universal series bus",
+      "storage",
+      "drive"
+    ]
+  },
+  {
+    "Code": "E88F",
+    "Name": "InkingToolFill",
+    "Tags": [
+      "draw",
+      "paint",
+      "sketch"
+    ]
+  },
+  {
+    "Code": "E890",
+    "Name": "View",
+    "Tags": [
+      "vision",
+      "see",
+      "eye",
+      "focus",
+      "look",
+      "password",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E891",
+    "Name": "HighlightFill",
+    "Tags": [
+      "marker",
+      "edit",
+      "draw",
+      "focus"
+    ]
+  },
+  {
+    "Code": "E892",
+    "Name": "Previous",
+    "Tags": [
+      "control",
+      "playback",
+      "start",
+      "begin",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E893",
+    "Name": "Next",
+    "Tags": [
+      "video",
+      "skip",
+      "jump",
+      "fast forward",
+      "play",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E894",
+    "Name": "Clear",
+    "Tags": [
+      "x",
+      "close",
+      "cancel",
+      "delete",
+      "remove",
+      "exit",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E895",
+    "Name": "Sync",
+    "Tags": [
+      "arrow",
+      "update",
+      "refresh",
+      "sync",
+      "refresh",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E896",
+    "Name": "Download",
+    "Tags": [
+      "arrow",
+      "file",
+      "save",
+      "retrieve",
+      "transfer",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E897",
+    "Name": "Help",
+    "Tags": [
+      "?",
+      "question",
+      "support",
+      "guide",
+      "assistance",
+      "info",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E898",
+    "Name": "Upload",
+    "Tags": [
+      "file",
+      "send",
+      "transfer",
+      "cloud",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E899",
+    "Name": "Emoji",
+    "Tags": [
+      "face",
+      "smiley",
+      "emote",
+      "feeling",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E89A",
+    "Name": "TwoPage",
+    "Tags": [
+      "2",
+      "document",
+      "file",
+      "sheet",
+      "paper",
+      "text",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E89B",
+    "Name": "LeaveChat",
+    "Tags": [
+      "exit",
+      "leave",
+      "message",
+      "conversation",
+      "disconnect",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E89C",
+    "Name": "MailForward",
+    "Tags": [
+      "send",
+      "arrow",
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "letter",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E89E",
+    "Name": "RotateCamera",
+    "Tags": [
+      "image",
+      "photography",
+      "picture",
+      "flip",
+      "switch",
+      "direction",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E89F",
+    "Name": "ClosePane",
+    "Tags": [
+      "sidebar",
+      "hide",
+      "exit",
+      "collapse",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A0",
+    "Name": "OpenPane",
+    "Tags": [
+      "sidebar",
+      "expand",
+      "menu",
+      "show",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A1",
+    "Name": "PreviewLink",
+    "Tags": [
+      "content",
+      "block",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A2",
+    "Name": "AttachCamera",
+    "Tags": [
+      "image",
+      "photography",
+      "picture",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A3",
+    "Name": "ZoomIn",
+    "Tags": [
+      "zoom out",
+      "magnifying glass",
+      "search",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A4",
+    "Name": "Bookmarks",
+    "Tags": [
+      "read",
+      "list",
+      "bullet points",
+      "formatting",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A5",
+    "Name": "Document",
+    "Tags": [
+      "page",
+      "file",
+      "sheet",
+      "paper",
+      "text",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A6",
+    "Name": "ProtectedDocument",
+    "Tags": [
+      "page",
+      "file",
+      "sheet",
+      "paper",
+      "text",
+      "secure",
+      "lock",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A7",
+    "Name": "OpenInNewWindow",
+    "Tags": [
+      "expand",
+      "external",
+      "launch",
+      "view",
+      "shortcut"
+    ]
+  },
+  {
+    "Code": "E8A8",
+    "Name": "MailFill",
+    "Tags": [
+      "email",
+      "message",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8A9",
+    "Name": "ViewAll",
+    "Tags": [
+      "list",
+      "browse",
+      "expand",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8AA",
+    "Name": "VideoChat",
+    "Tags": [
+      "call",
+      "camera",
+      "conversation",
+      "meeting",
+      "connect",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8AB",
+    "Name": "Switch",
+    "Tags": [
+      "arrow",
+      "change",
+      "swap",
+      "toggle",
+      "shift",
+      "alternate",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8AC",
+    "Name": "Rename",
+    "Tags": [
+      "input",
+      "text",
+      "type",
+      "info",
+      "ui",
+      "box",
+      "form",
+      "edit",
+      "change",
+      "modify",
+      "label",
+      "update",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8AD",
+    "Name": "Go",
+    "Tags": [
+      "arrow",
+      "start",
+      "move",
+      "launch",
+      "begin",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8AE",
+    "Name": "SurfaceHub",
+    "Tags": [
+      "device",
+      "physical",
+      "product",
+      "screen",
+      "touch screen",
+      "presentation"
+    ]
+  },
+  {
+    "Code": "E8AF",
+    "Name": "Remote",
+    "Tags": [
+      "cloud",
+      "connect",
+      "device",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B0",
+    "Name": "Click",
+    "Tags": [
+      "pointer",
+      "tap",
+      "press",
+      "select",
+      "activate",
+      "choose"
+    ]
+  },
+  {
+    "Code": "E8B1",
+    "Name": "Shuffle",
+    "Tags": [
+      "arrow",
+      "random",
+      "mix",
+      "rearrange",
+      "order",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B2",
+    "Name": "Movies",
+    "Tags": [
+      "cinema",
+      "entertainment",
+      "video",
+      "screen"
+    ]
+  },
+  {
+    "Code": "E8B3",
+    "Name": "SelectAll",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark",
+      "check multiple",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B4",
+    "Name": "Orientation",
+    "Tags": [
+      "rotate",
+      "horizontal",
+      "vertical",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B5",
+    "Name": "Import",
+    "Tags": [
+      "arrow",
+      "upload",
+      "file",
+      "add",
+      "transfer",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B6",
+    "Name": "ImportAll",
+    "Tags": [
+      "arrow",
+      "arrow",
+      "upload",
+      "file",
+      "add",
+      "transfer",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B7",
+    "Name": "Folder",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B8",
+    "Name": "Webcam",
+    "Tags": [
+      "capture",
+      "stream",
+      "meeting",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8B9",
+    "Name": "Picture",
+    "Tags": [
+      "image",
+      "photo",
+      "snapshot",
+      "portrait",
+      "frame",
+      "gallery",
+      "canvas",
+      "visual",
+      "view",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8BA",
+    "Name": "Caption",
+    "Tags": [
+      "image",
+      "photo",
+      "snapshot",
+      "portrait",
+      "frame",
+      "gallery",
+      "canvas",
+      "visual",
+      "view",
+      "label",
+      "text",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8BB",
+    "Name": "ChromeClose",
+    "Tags": [
+      "x",
+      "exit",
+      "cancel",
+      "shut",
+      "dismiss"
+    ]
+  },
+  {
+    "Code": "E8BC",
+    "Name": "ShowResults",
+    "Tags": [
+      "list",
+      "bullet points",
+      "formatting",
+      "display",
+      "view",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8BD",
+    "Name": "Message",
+    "Tags": [
+      "chat",
+      "message",
+      "text",
+      "notification",
+      "bubble",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8BE",
+    "Name": "Leaf",
+    "Tags": [
+      "nature",
+      "eco",
+      "environment",
+      "sustainability",
+      "green"
+    ]
+  },
+  {
+    "Code": "E8BF",
+    "Name": "CalendarDay",
+    "Tags": [
+      "time",
+      "date",
+      "planning",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C0",
+    "Name": "CalendarWeek",
+    "Tags": [
+      "time",
+      "date",
+      "planning",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C1",
+    "Name": "Characters",
+    "Tags": [
+      "letters",
+      "symbols",
+      "alphabet",
+      "writing",
+      "glyphs",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C2",
+    "Name": "MailReplyAll",
+    "Tags": [
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "respond",
+      "letter",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C3",
+    "Name": "Read",
+    "Tags": [
+      "mail",
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "letter",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C4",
+    "Name": "ShowBcc",
+    "Tags": [
+      "email",
+      "recipient",
+      "hidden",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C5",
+    "Name": "HideBcc",
+    "Tags": [
+      "email",
+      "bcc",
+      "hide",
+      "privacy",
+      "recipient",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C6",
+    "Name": "Cut",
+    "Tags": [
+      "copy",
+      "paste",
+      "share",
+      "move",
+      "transfer",
+      "clipboard",
+      "clip",
+      "edit",
+      "trim",
+      "divide",
+      "scissors",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C7",
+    "Name": "PaymentCard",
+    "Tags": [
+      "currency",
+      "money",
+      "credit card"
+    ]
+  },
+  {
+    "Code": "E8C8",
+    "Name": "Copy",
+    "Tags": [
+      "share",
+      "paste",
+      "clipboard",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8C9",
+    "Name": "Important",
+    "Tags": [
+      "!",
+      "priority",
+      "highlight",
+      "urgent",
+      "attention",
+      "critical",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8CA",
+    "Name": "MailReply",
+    "Tags": [
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "respond",
+      "letter",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8CB",
+    "Name": "Sort",
+    "Tags": [
+      "arrow",
+      "arrange",
+      "order",
+      "filter",
+      "organize",
+      "sequence",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8CC",
+    "Name": "MobileTablet",
+    "Tags": [
+      "device",
+      "screen",
+      "physical",
+      "watch",
+      "view",
+      "video",
+      "phone"
+    ]
+  },
+  {
+    "Code": "E8CD",
+    "Name": "DisconnectDrive",
+    "Tags": [
+      "remove",
+      "unmount",
+      "eject",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8CE",
+    "Name": "MapDrive",
+    "Tags": [
+      "network",
+      "connect",
+      "link",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8CF",
+    "Name": "ContactPresence",
+    "Tags": [
+      "status",
+      "availability",
+      "online",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D0",
+    "Name": "Priority",
+    "Tags": [
+      "!",
+      "arrow",
+      "importance",
+      "urgent",
+      "priority",
+      "focus",
+      "high",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D1",
+    "Name": "GotoToday",
+    "Tags": [
+      "calendar",
+      "date",
+      "time",
+      "planning",
+      "jump",
+      "current",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D2",
+    "Name": "Font",
+    "Tags": [
+      "text",
+      "style",
+      "size",
+      "lettering",
+      "typography",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D3",
+    "Name": "FontColor",
+    "Tags": [
+      "text",
+      "style",
+      "size",
+      "lettering",
+      "typography",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D4",
+    "Name": "Contact2",
+    "Tags": [
+      "person",
+      "user",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D5",
+    "Name": "FolderFill",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "E8D6",
+    "Name": "Audio",
+    "Tags": [
+      "music",
+      "sound",
+      "note",
+      "play",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D7",
+    "Name": "Permissions",
+    "Tags": [
+      "key",
+      "security",
+      "password",
+      "access",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D8",
+    "Name": "DisableUpdates",
+    "Tags": [
+      "arrow",
+      "settings",
+      "off",
+      "pause",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8D9",
+    "Name": "Unfavorite",
+    "Tags": [
+      "star",
+      "remove",
+      "unlike",
+      "delete",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8DA",
+    "Name": "OpenLocal",
+    "Tags": [
+      "folder",
+      "directory",
+      "file",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8DB",
+    "Name": "Italic",
+    "Tags": [
+      "text",
+      "style",
+      "slant",
+      "font",
+      "emphasis",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8DC",
+    "Name": "Underline",
+    "Tags": [
+      "text",
+      "style",
+      "font",
+      "emphasis",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8DD",
+    "Name": "Bold",
+    "Tags": [
+      "text",
+      "style",
+      "strong",
+      "font",
+      "emphasis",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8DE",
+    "Name": "MoveToFolder",
+    "Tags": [
+      "file",
+      "organize",
+      "transfer",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8DF",
+    "Name": "LikeDislike",
+    "Tags": [
+      "reaction",
+      "feedback",
+      "vote",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E0",
+    "Name": "Dislike",
+    "Tags": [
+      "thumb",
+      "positive",
+      "approve",
+      "favor",
+      "agree",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E1",
+    "Name": "Like",
+    "Tags": [
+      "thumb",
+      "negative",
+      "reject",
+      "disapprove",
+      "oppose",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E2",
+    "Name": "AlignRight",
+    "Tags": [
+      "text",
+      "justify",
+      "position",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E3",
+    "Name": "AlignCenter",
+    "Tags": [
+      "text",
+      "justify",
+      "position",
+      "middle",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E4",
+    "Name": "AlignLeft",
+    "Tags": [
+      "text",
+      "justify",
+      "position",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E5",
+    "Name": "OpenFile",
+    "Tags": [
+      "document",
+      "page",
+      "view",
+      "access",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E6",
+    "Name": "ClearSelection",
+    "Tags": [
+      "check",
+      "checkmark",
+      "check multiple",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E7",
+    "Name": "FontDecrease",
+    "Tags": [
+      "text",
+      "size",
+      "smaller",
+      "reduce",
+      "adjust",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E8",
+    "Name": "FontIncrease",
+    "Tags": [
+      "text",
+      "size",
+      "larger",
+      "enlarge",
+      "adjust",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8E9",
+    "Name": "FontSize",
+    "Tags": [
+      "text",
+      "adjust",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8EA",
+    "Name": "CellPhone",
+    "Tags": [
+      "device",
+      "mobile",
+      "small screen",
+      "cellular telephone",
+      "apple",
+      "android",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8EB",
+    "Name": "Reshare",
+    "Tags": [
+      "arrow",
+      "repost",
+      "forward",
+      "distribute",
+      "spread",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8EC",
+    "Name": "Tag",
+    "Tags": [
+      "label",
+      "price",
+      "information",
+      "detail",
+      "metadata",
+      "purchase",
+      "sort",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8ED",
+    "Name": "RepeatOne",
+    "Tags": [
+      "arrow",
+      "single",
+      "loop",
+      "song",
+      "track",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8EE",
+    "Name": "RepeatAll",
+    "Tags": [
+      "arrow",
+      "loop",
+      "song",
+      "track",
+      "playlist",
+      "continuous",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8EF",
+    "Name": "Calculator",
+    "Tags": [
+      "math",
+      "formulas",
+      "add",
+      "subtract",
+      "multiply",
+      "divde",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F0",
+    "Name": "Directions",
+    "Tags": [
+      "arrow",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F1",
+    "Name": "Library",
+    "Tags": [
+      "books",
+      "collection",
+      "library",
+      "archive",
+      "resources",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F2",
+    "Name": "ChatBubbles",
+    "Tags": [
+      "message",
+      "text",
+      "message",
+      "conversation",
+      "talk"
+    ]
+  },
+  {
+    "Code": "E8F3",
+    "Name": "PostUpdate",
+    "Tags": [
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F4",
+    "Name": "NewFolder",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage",
+      "plus",
+      "new",
+      "+",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F5",
+    "Name": "CalendarReply",
+    "Tags": [
+      "time",
+      "date",
+      "planning",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F6",
+    "Name": "UnsyncFolder",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage",
+      "disconnect",
+      "offline",
+      "remove",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F7",
+    "Name": "SyncFolder",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage",
+      "connect",
+      "update",
+      "refresh",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F8",
+    "Name": "BlockContact",
+    "Tags": [
+      "person",
+      "user",
+      "restrict",
+      "privacy",
+      "remove",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8F9",
+    "Name": "SwitchApps",
+    "Tags": [
+      "change",
+      "transition",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8FA",
+    "Name": "AddFriend",
+    "Tags": [
+      "person",
+      "user",
+      "connect",
+      "social",
+      "relationship",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8FB",
+    "Name": "Accept",
+    "Tags": [
+      "check",
+      "agree",
+      "approve",
+      "confirm",
+      "approve",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8FC",
+    "Name": "GoToStart",
+    "Tags": [
+      "home",
+      "begin",
+      "windows",
+      "navigate",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8FD",
+    "Name": "BulletedList",
+    "Tags": [
+      "organize",
+      "items",
+      "points",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8FE",
+    "Name": "Scan",
+    "Tags": [
+      "camera",
+      "aperture",
+      "image",
+      "picture",
+      "scan",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E8FF",
+    "Name": "Preview",
+    "Tags": [
+      "document",
+      "preview",
+      "view",
+      "file",
+      "read",
+      "page",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E902",
+    "Name": "Group",
+    "Tags": [
+      "person",
+      "user",
+      "people",
+      "team",
+      "crowd",
+      "community"
+    ]
+  },
+  {
+    "Code": "E904",
+    "Name": "ZeroBars",
+    "Tags": [
+      "no signal",
+      "connection",
+      "lost",
+      "weak",
+      "empty",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E905",
+    "Name": "OneBar",
+    "Tags": [
+      "weak signal",
+      "connection",
+      "low",
+      "signal",
+      "poor",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E906",
+    "Name": "TwoBars",
+    "Tags": [
+      "signal",
+      "connection",
+      "fair",
+      "moderate",
+      "average",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E907",
+    "Name": "ThreeBars",
+    "Tags": [
+      "good signal",
+      "connection",
+      "strong",
+      "stable",
+      "high",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E908",
+    "Name": "FourBars",
+    "Tags": [
+      "full signal",
+      "excellent",
+      "connection",
+      "strong",
+      "maximum",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E909",
+    "Name": "World",
+    "Tags": [
+      "globe",
+      "earth",
+      "international",
+      "global",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E90A",
+    "Name": "Comment",
+    "Tags": [
+      "chat",
+      "message",
+      "mention",
+      "discussion",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E90B",
+    "Name": "MusicInfo",
+    "Tags": [
+      "musician",
+      "art",
+      "music",
+      "info",
+      "song",
+      "track",
+      "details",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E90C",
+    "Name": "DockLeft",
+    "Tags": [
+      "position",
+      "side",
+      "panel",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E90D",
+    "Name": "DockRight",
+    "Tags": [
+      "position",
+      "side",
+      "panel",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E90E",
+    "Name": "DockBottom",
+    "Tags": [
+      "position",
+      "side",
+      "panel",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E90F",
+    "Name": "Repair",
+    "Tags": [
+      "wrench",
+      "tool",
+      "fix",
+      "restore",
+      "correct",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E910",
+    "Name": "Accounts",
+    "Tags": [
+      "@",
+      "at",
+      "email",
+      "address",
+      "symbol",
+      "communication",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E911",
+    "Name": "DullSound",
+    "Tags": []
+  },
+  {
+    "Code": "E912",
+    "Name": "Manage",
+    "Tags": [
+      "bag",
+      "handbag",
+      "briefcase",
+      "control",
+      "organize",
+      "administer",
+      "oversee",
+      "handle",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E913",
+    "Name": "Street",
+    "Tags": [
+      "road",
+      "address",
+      "location",
+      "avenue",
+      "way",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E914",
+    "Name": "Printer3D",
+    "Tags": [
+      "design",
+      "model",
+      "fabricate",
+      "technology",
+      "create"
+    ]
+  },
+  {
+    "Code": "E915",
+    "Name": "RadioBullet",
+    "Tags": [
+      "dot",
+      "circle"
+    ]
+  },
+  {
+    "Code": "E916",
+    "Name": "Stopwatch",
+    "Tags": [
+      "time",
+      "clock"
+    ]
+  },
+  {
+    "Code": "E91B",
+    "Name": "Photo",
+    "Tags": [
+      "image",
+      "picture",
+      "snapshot",
+      "portrait",
+      "frame",
+      "gallery",
+      "canvas",
+      "visual",
+      "view"
+    ]
+  },
+  {
+    "Code": "E91C",
+    "Name": "ActionCenter",
+    "Tags": [
+      "notification",
+      "message",
+      "settings",
+      "control",
+      "quick access",
+      "system"
+    ]
+  },
+  {
+    "Code": "E91F",
+    "Name": "FullCircleMask",
+    "Tags": [
+      "shape",
+      "round",
+      "border"
+    ]
+  },
+  {
+    "Code": "E921",
+    "Name": "ChromeMinimize",
+    "Tags": [
+      "window",
+      "shrink",
+      "small",
+      "collapse",
+      "resize"
+    ]
+  },
+  {
+    "Code": "E922",
+    "Name": "ChromeMaximize",
+    "Tags": [
+      "window",
+      "expand",
+      "full screen",
+      "enlarge",
+      "width",
+      "height",
+      "resize",
+      "fill",
+      "fit"
+    ]
+  },
+  {
+    "Code": "E923",
+    "Name": "ChromeRestore",
+    "Tags": [
+      "window",
+      "resize",
+      "default",
+      "revert"
+    ]
+  },
+  {
+    "Code": "E924",
+    "Name": "Annotation",
+    "Tags": [
+      "cut",
+      "edit",
+      "scissors",
+      "mark",
+      "highlight"
+    ]
+  },
+  {
+    "Code": "E925",
+    "Name": "BackSpaceQWERTYSm",
+    "Tags": [
+      "delete",
+      "backward",
+      "remove",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E926",
+    "Name": "BackSpaceQWERTYMd",
+    "Tags": [
+      "delete",
+      "backward",
+      "remove",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E927",
+    "Name": "Swipe",
+    "Tags": [
+      "gesture",
+      "touch screen",
+      "mobile",
+      "tablet"
+    ]
+  },
+  {
+    "Code": "E928",
+    "Name": "Fingerprint",
+    "Tags": [
+      "scan",
+      "security",
+      "hand"
+    ]
+  },
+  {
+    "Code": "E929",
+    "Name": "Handwriting",
+    "Tags": [
+      "write",
+      "pen",
+      "gesture",
+      "scribble",
+      "draw"
+    ]
+  },
+  {
+    "Code": "E92C",
+    "Name": "ChromeBackToWindow",
+    "Tags": [
+      "arrow",
+      "restore",
+      "return",
+      "minimize"
+    ]
+  },
+  {
+    "Code": "E92D",
+    "Name": "ChromeFullScreen",
+    "Tags": [
+      "arrow",
+      "expand",
+      "maximize",
+      "window",
+      "view"
+    ]
+  },
+  {
+    "Code": "E92E",
+    "Name": "KeyboardStandard",
+    "Tags": [
+      "type",
+      "key",
+      "device",
+      "hardware"
+    ]
+  },
+  {
+    "Code": "E92F",
+    "Name": "KeyboardDismiss",
+    "Tags": [
+      "type",
+      "key",
+      "device",
+      "hardware",
+      "close",
+      "hide",
+      "exit"
+    ]
+  },
+  {
+    "Code": "E930",
+    "Name": "Completed",
+    "Tags": [
+      "check",
+      "finished",
+      "done",
+      "achieved",
+      "success"
+    ]
+  },
+  {
+    "Code": "E931",
+    "Name": "ChromeAnnotate",
+    "Tags": [
+      "cut",
+      "edit",
+      "scissors",
+      "mark",
+      "highlight"
+    ]
+  },
+  {
+    "Code": "E932",
+    "Name": "Label",
+    "Tags": [
+      "edit",
+      "tag",
+      "identifier",
+      "caption",
+      "name",
+      "marker"
+    ]
+  },
+  {
+    "Code": "E933",
+    "Name": "IBeam",
+    "Tags": [
+      "cursor",
+      "text",
+      "select",
+      "pointer",
+      "edit"
+    ]
+  },
+  {
+    "Code": "E934",
+    "Name": "IBeamOutline",
+    "Tags": [
+      "cursor",
+      "text",
+      "select",
+      "pointer",
+      "edit"
+    ]
+  },
+  {
+    "Code": "E935",
+    "Name": "FlickDown",
+    "Tags": [
+      "triangle",
+      "gesture",
+      "swipe",
+      "scroll",
+      "move"
+    ]
+  },
+  {
+    "Code": "E936",
+    "Name": "FlickUp",
+    "Tags": [
+      "triangle",
+      "gesture",
+      "swipe",
+      "scroll",
+      "move"
+    ]
+  },
+  {
+    "Code": "E937",
+    "Name": "FlickLeft",
+    "Tags": [
+      "triangle",
+      "gesture",
+      "swipe",
+      "scroll",
+      "navigate"
+    ]
+  },
+  {
+    "Code": "E938",
+    "Name": "FlickRight",
+    "Tags": [
+      "triangle",
+      "gesture",
+      "swipe",
+      "scroll",
+      "navigate"
+    ]
+  },
+  {
+    "Code": "E939",
+    "Name": "FeedbackApp",
+    "Tags": [
+      "person",
+      "user",
+      "review",
+      "response",
+      "evaluation"
+    ]
+  },
+  {
+    "Code": "E93C",
+    "Name": "MusicAlbum",
+    "Tags": [
+      "collection",
+      "tracks",
+      "playlist"
+    ]
+  },
+  {
+    "Code": "E93E",
+    "Name": "Streaming",
+    "Tags": [
+      "media",
+      "live",
+      "video",
+      "broadcast",
+      "online"
+    ]
+  },
+  {
+    "Code": "E943",
+    "Name": "Code",
+    "Tags": [
+      "bracket",
+      "slash"
+    ]
+  },
+  {
+    "Code": "E944",
+    "Name": "ReturnToWindow",
+    "Tags": [
+      "arrow",
+      "restore",
+      "back",
+      "minimize"
+    ]
+  },
+  {
+    "Code": "E945",
+    "Name": "LightningBolt",
+    "Tags": [
+      "thunder",
+      "energy",
+      "power",
+      "electricity",
+      "shock",
+      "storm"
+    ]
+  },
+  {
+    "Code": "E946",
+    "Name": "Info",
+    "Tags": [
+      "information",
+      "details",
+      "content"
+    ]
+  },
+  {
+    "Code": "E947",
+    "Name": "CalculatorMultiply",
+    "Tags": [
+      "x",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E948",
+    "Name": "CalculatorAddition",
+    "Tags": [
+      "+",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E949",
+    "Name": "CalculatorSubtract",
+    "Tags": [
+      "-",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E94A",
+    "Name": "CalculatorDivide",
+    "Tags": [
+      "/",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E94B",
+    "Name": "CalculatorSquareroot",
+    "Tags": [
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E94C",
+    "Name": "CalculatorPercentage",
+    "Tags": [
+      "%",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E94D",
+    "Name": "CalculatorNegate",
+    "Tags": [
+      "-",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E94E",
+    "Name": "CalculatorEqualTo",
+    "Tags": [
+      "=",
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E94F",
+    "Name": "CalculatorBackspace",
+    "Tags": [
+      "math",
+      "operation",
+      "symbol",
+      "arithmetic"
+    ]
+  },
+  {
+    "Code": "E950",
+    "Name": "Component",
+    "Tags": [
+      "chip",
+      "semiconductor",
+      "processor",
+      "circuit",
+      "electronics",
+      "technology",
+      "hardware"
+    ]
+  },
+  {
+    "Code": "E951",
+    "Name": "DMC",
+    "Tags": [
+      "control",
+      "remote",
+      "device",
+      "access",
+      "operate"
+    ]
+  },
+  {
+    "Code": "E952",
+    "Name": "Dock",
+    "Tags": [
+      "device"
+    ]
+  },
+  {
+    "Code": "E953",
+    "Name": "MultimediaDMS",
+    "Tags": [
+      "server",
+      "stream",
+      "share",
+      "content"
+    ]
+  },
+  {
+    "Code": "E954",
+    "Name": "MultimediaDVR",
+    "Tags": [
+      "record",
+      "video",
+      "tv",
+      "capture"
+    ]
+  },
+  {
+    "Code": "E955",
+    "Name": "MultimediaPMP",
+    "Tags": [
+      "player",
+      "portable",
+      "music",
+      "device"
+    ]
+  },
+  {
+    "Code": "E956",
+    "Name": "PrintfaxPrinterFile",
+    "Tags": [
+      "document",
+      "page"
+    ]
+  },
+  {
+    "Code": "E957",
+    "Name": "Sensor",
+    "Tags": [
+      "device",
+      "measurement",
+      "detection",
+      "technology",
+      "input"
+    ]
+  },
+  {
+    "Code": "E958",
+    "Name": "StorageOptical",
+    "Tags": [
+      "disk",
+      "media",
+      "drive"
+    ]
+  },
+  {
+    "Code": "E95A",
+    "Name": "Communications",
+    "Tags": [
+      "cast",
+      "connect",
+      "wifi",
+      "share"
+    ]
+  },
+  {
+    "Code": "E95B",
+    "Name": "Headset",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume",
+      "device",
+      "support",
+      "help"
+    ]
+  },
+  {
+    "Code": "E95D",
+    "Name": "Projector",
+    "Tags": [
+      "screen",
+      "display",
+      "project",
+      "visual",
+      "presentation"
+    ]
+  },
+  {
+    "Code": "E95E",
+    "Name": "Health",
+    "Tags": [
+      "heart",
+      "health",
+      "medical",
+      "care",
+      "wellness",
+      "fitness"
+    ]
+  },
+  {
+    "Code": "E95F",
+    "Name": "Wire",
+    "Tags": [
+      "plug",
+      "electricity",
+      "connection",
+      "power",
+      "cord"
+    ]
+  },
+  {
+    "Code": "E960",
+    "Name": "Webcam2",
+    "Tags": [
+      "camera",
+      "capture",
+      "stream",
+      "meeting"
+    ]
+  },
+  {
+    "Code": "E961",
+    "Name": "Input",
+    "Tags": [
+      "keyboard",
+      "mouse",
+      "hardware"
+    ]
+  },
+  {
+    "Code": "E962",
+    "Name": "Mouse",
+    "Tags": [
+      "pointer",
+      "device",
+      "input",
+      "click"
+    ]
+  },
+  {
+    "Code": "E963",
+    "Name": "Smartcard",
+    "Tags": [
+      "chip",
+      "security",
+      "payment"
+    ]
+  },
+  {
+    "Code": "E964",
+    "Name": "SmartcardVirtual",
+    "Tags": [
+      "virtual",
+      "security",
+      "digital",
+      "chip"
+    ]
+  },
+  {
+    "Code": "E965",
+    "Name": "MediaStorageTower",
+    "Tags": [
+      "device",
+      "backup"
+    ]
+  },
+  {
+    "Code": "E966",
+    "Name": "ReturnKeySm",
+    "Tags": [
+      "arrow",
+      "enter",
+      "submit",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E967",
+    "Name": "GameConsole",
+    "Tags": [
+      "device",
+      "entertainment"
+    ]
+  },
+  {
+    "Code": "E968",
+    "Name": "Network",
+    "Tags": [
+      "remote",
+      "network adapter",
+      "hardware",
+      "device"
+    ]
+  },
+  {
+    "Code": "E969",
+    "Name": "StorageNetworkWireless",
+    "Tags": [
+      "remote",
+      "data",
+      "connection"
+    ]
+  },
+  {
+    "Code": "E96A",
+    "Name": "StorageTape",
+    "Tags": [
+      "cassette",
+      "backup",
+      "media",
+      "archival"
+    ]
+  },
+  {
+    "Code": "E96D",
+    "Name": "ChevronUpSmall",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E96E",
+    "Name": "ChevronDownSmall",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E96F",
+    "Name": "ChevronLeftSmall",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E970",
+    "Name": "ChevronRightSmall",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E971",
+    "Name": "ChevronUpMed",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E972",
+    "Name": "ChevronDownMed",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E973",
+    "Name": "ChevronLeftMed",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E974",
+    "Name": "ChevronRightMed",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "E975",
+    "Name": "Devices2",
+    "Tags": [
+      "hardware",
+      "connections",
+      "peripherals",
+      "electronics",
+      "gadgets"
+    ]
+  },
+  {
+    "Code": "E976",
+    "Name": "ExpandTile",
+    "Tags": [
+      "maximize",
+      "view",
+      "window"
+    ]
+  },
+  {
+    "Code": "E977",
+    "Name": "PC1",
+    "Tags": [
+      "computer",
+      "personal",
+      "device",
+      "desktop",
+      "technology"
+    ]
+  },
+  {
+    "Code": "E978",
+    "Name": "PresenceChicklet",
+    "Tags": [
+      "stop",
+      "pause",
+      "end",
+      "cease",
+      "interrupt"
+    ]
+  },
+  {
+    "Code": "E979",
+    "Name": "PresenceChickletVideo",
+    "Tags": [
+      "camera",
+      "image",
+      "photography",
+      "picture"
+    ]
+  },
+  {
+    "Code": "E97A",
+    "Name": "Reply",
+    "Tags": [
+      "arrow",
+      "respond",
+      "answer",
+      "return"
+    ]
+  },
+  {
+    "Code": "E97B",
+    "Name": "SetTile",
+    "Tags": [
+      "arrow",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E97C",
+    "Name": "Type",
+    "Tags": []
+  },
+  {
+    "Code": "E97D",
+    "Name": "Korean",
+    "Tags": [
+      "language",
+      "Korean",
+      "hangul",
+      "alphabet"
+    ]
+  },
+  {
+    "Code": "E97E",
+    "Name": "HalfAlpha",
+    "Tags": [
+      "letter",
+      "character",
+      "symbol"
+    ]
+  },
+  {
+    "Code": "E97F",
+    "Name": "FullAlpha",
+    "Tags": [
+      "letter",
+      "character",
+      "symbol"
+    ]
+  },
+  {
+    "Code": "E980",
+    "Name": "Key12On",
+    "Tags": [
+      "language",
+      "Korean",
+      "hangul"
+    ]
+  },
+  {
+    "Code": "E981",
+    "Name": "ChineseChangjie",
+    "Tags": [
+      "input",
+      "method",
+      "characters"
+    ]
+  },
+  {
+    "Code": "E982",
+    "Name": "QWERTYOn",
+    "Tags": [
+      "chinese"
+    ]
+  },
+  {
+    "Code": "E983",
+    "Name": "QWERTYOff",
+    "Tags": [
+      "chinese",
+      "english"
+    ]
+  },
+  {
+    "Code": "E984",
+    "Name": "ChineseQuick",
+    "Tags": [
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E985",
+    "Name": "Japanese",
+    "Tags": [
+      "Kanji",
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E986",
+    "Name": "FullHiragana",
+    "Tags": [
+      "japanese",
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E987",
+    "Name": "FullKatakana",
+    "Tags": [
+      "japanese",
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E988",
+    "Name": "HalfKatakana",
+    "Tags": [
+      "japanese",
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E989",
+    "Name": "ChineseBoPoMoFo",
+    "Tags": [
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E98A",
+    "Name": "ChinesePinyin",
+    "Tags": [
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "E98F",
+    "Name": "ConstructionCone",
+    "Tags": [
+      "warning",
+      "caution",
+      "barrier"
+    ]
+  },
+  {
+    "Code": "E990",
+    "Name": "XboxOneConsole",
+    "Tags": [
+      "device",
+      "videogame",
+      "game",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "E992",
+    "Name": "Volume0",
+    "Tags": [
+      "sound",
+      "audio",
+      "level",
+      "speaker"
+    ]
+  },
+  {
+    "Code": "E993",
+    "Name": "Volume1",
+    "Tags": [
+      "sound",
+      "audio",
+      "level",
+      "speaker"
+    ]
+  },
+  {
+    "Code": "E994",
+    "Name": "Volume2",
+    "Tags": [
+      "sound",
+      "audio",
+      "level",
+      "speaker"
+    ]
+  },
+  {
+    "Code": "E995",
+    "Name": "Volume3",
+    "Tags": [
+      "sound",
+      "audio",
+      "level",
+      "speaker"
+    ]
+  },
+  {
+    "Code": "E996",
+    "Name": "BatteryUnknown",
+    "Tags": [
+      "charge",
+      "power",
+      "status"
+    ]
+  },
+  {
+    "Code": "E998",
+    "Name": "WifiAttentionOverlay",
+    "Tags": [
+      "!",
+      "warning",
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "E99A",
+    "Name": "Robot",
+    "Tags": [
+      "automation",
+      "machine",
+      "technology",
+      "AI",
+      "Artificial",
+      "intelligence"
+    ]
+  },
+  {
+    "Code": "E9A1",
+    "Name": "TapAndSend",
+    "Tags": [
+      "hand",
+      "touch",
+      "gesture",
+      "physical",
+      "paper plane",
+      "mail",
+      "message"
+    ]
+  },
+  {
+    "Code": "E9A4",
+    "Name": "TextBulletListSquare",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "E9A6",
+    "Name": "FitPage",
+    "Tags": [
+      "resize",
+      "view",
+      "adjust"
+    ]
+  },
+  {
+    "Code": "E9A8",
+    "Name": "PasswordKeyShow",
+    "Tags": [
+      "reveal",
+      "security",
+      "visibility",
+      "protection",
+      "access"
+    ]
+  },
+  {
+    "Code": "E9A9",
+    "Name": "PasswordKeyHide",
+    "Tags": [
+      "conceal",
+      "security",
+      "visibility",
+      "protection",
+      "access"
+    ]
+  },
+  {
+    "Code": "E9AA",
+    "Name": "BidiLtr",
+    "Tags": [
+      "text",
+      "left",
+      "direction",
+      "language",
+      "alignment"
+    ]
+  },
+  {
+    "Code": "E9AB",
+    "Name": "BidiRtl",
+    "Tags": [
+      "text",
+      "right",
+      "direction",
+      "language",
+      "alignment"
+    ]
+  },
+  {
+    "Code": "E9AC",
+    "Name": "ForwardSm",
+    "Tags": [
+      "arrow",
+      "next",
+      "send",
+      "right",
+      "proceed"
+    ]
+  },
+  {
+    "Code": "E9AD",
+    "Name": "CommaKey",
+    "Tags": [
+      "`",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9AE",
+    "Name": "DashKey",
+    "Tags": [
+      "-",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9AF",
+    "Name": "DullSoundKey",
+    "Tags": [
+      "japanese"
+    ]
+  },
+  {
+    "Code": "E9B0",
+    "Name": "HalfDullSound",
+    "Tags": [
+      "japanese"
+    ]
+  },
+  {
+    "Code": "E9B1",
+    "Name": "RightDoubleQuote",
+    "Tags": [
+      "\"",
+      "punctuation",
+      "key",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B2",
+    "Name": "LeftDoubleQuote",
+    "Tags": [
+      "\"",
+      "punctuation",
+      "key",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B3",
+    "Name": "PuncKeyRightBottom",
+    "Tags": [
+      ".",
+      ","
+    ]
+  },
+  {
+    "Code": "E9B4",
+    "Name": "PuncKey1",
+    "Tags": [
+      "@",
+      "&",
+      "#",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B5",
+    "Name": "PuncKey2",
+    "Tags": [
+      "\\",
+      "|",
+      "/",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B6",
+    "Name": "PuncKey3",
+    "Tags": [
+      "+",
+      "=",
+      "-",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B7",
+    "Name": "PuncKey4",
+    "Tags": [
+      ".",
+      "*",
+      "&",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B8",
+    "Name": "PuncKey5",
+    "Tags": [
+      "<",
+      "^",
+      ">",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9B9",
+    "Name": "PuncKey6",
+    "Tags": [
+      "~",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9BA",
+    "Name": "PuncKey9",
+    "Tags": [
+      ":",
+      ";",
+      "_",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9BB",
+    "Name": "PuncKey7",
+    "Tags": [
+      "$",
+      "¥",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9BC",
+    "Name": "PuncKey8",
+    "Tags": [
+      "x",
+      "×",
+      "÷",
+      "math",
+      "punctuation",
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "E9CA",
+    "Name": "Frigid",
+    "Tags": [
+      "temperature",
+      "thermometer",
+      "measurement",
+      "heat"
+    ]
+  },
+  {
+    "Code": "E9CE",
+    "Name": "Unknown",
+    "Tags": [
+      "?",
+      "question",
+      "uncertain"
+    ]
+  },
+  {
+    "Code": "E9D2",
+    "Name": "AreaChart",
+    "Tags": [
+      "graph",
+      "data",
+      "visual",
+      "analysis",
+      "statistics",
+      "representation"
+    ]
+  },
+  {
+    "Code": "E9D5",
+    "Name": "CheckList",
+    "Tags": [
+      "tasks",
+      "items",
+      "organize",
+      "progress",
+      "completion"
+    ]
+  },
+  {
+    "Code": "E9D9",
+    "Name": "Diagnostic",
+    "Tags": [
+      "analysis",
+      "assessment",
+      "evaluation",
+      "rate",
+      "heart",
+      "beat"
+    ]
+  },
+  {
+    "Code": "E9E9",
+    "Name": "Equalizer",
+    "Tags": [
+      "sound",
+      "audio",
+      "music",
+      "volume"
+    ]
+  },
+  {
+    "Code": "E9F3",
+    "Name": "Process",
+    "Tags": [
+      "arrow",
+      "workflow",
+      "operation"
+    ]
+  },
+  {
+    "Code": "E9F5",
+    "Name": "Processing",
+    "Tags": [
+      "settings",
+      "workflow",
+      "operation"
+    ]
+  },
+  {
+    "Code": "E9F9",
+    "Name": "ReportDocument",
+    "Tags": [
+      "summary",
+      "file",
+      "analysis"
+    ]
+  },
+  {
+    "Code": "EA0C",
+    "Name": "VideoSolid",
+    "Tags": [
+      "camera",
+      "image",
+      "photography",
+      "picture"
+    ]
+  },
+  {
+    "Code": "EA0D",
+    "Name": "MixedMediaBadge",
+    "Tags": [
+      "shield",
+      "window"
+    ]
+  },
+  {
+    "Code": "EA14",
+    "Name": "DisconnectDisplay",
+    "Tags": [
+      "screen",
+      "monitor",
+      "remove"
+    ]
+  },
+  {
+    "Code": "EA18",
+    "Name": "Shield",
+    "Tags": [
+      "security",
+      "protection",
+      "safety"
+    ]
+  },
+  {
+    "Code": "EA1F",
+    "Name": "Info2",
+    "Tags": [
+      "information",
+      "details",
+      "content"
+    ]
+  },
+  {
+    "Code": "EA21",
+    "Name": "ActionCenterAsterisk",
+    "Tags": [
+      "*",
+      "notification",
+      "alert"
+    ]
+  },
+  {
+    "Code": "EA24",
+    "Name": "Beta",
+    "Tags": [
+      "symbol",
+      "letter",
+      "math"
+    ]
+  },
+  {
+    "Code": "EA35",
+    "Name": "SaveCopy",
+    "Tags": [
+      "floppy",
+      "floppy disk",
+      "device",
+      "old"
+    ]
+  },
+  {
+    "Code": "EA37",
+    "Name": "List",
+    "Tags": [
+      "text",
+      "line",
+      "view",
+      "symbol-icon"
+    ]
+  },
+  {
+    "Code": "EA38",
+    "Name": "Asterisk",
+    "Tags": [
+      "*",
+      "star",
+      "symbol",
+      "wildcard",
+      "mark",
+      "notation"
+    ]
+  },
+  {
+    "Code": "EA39",
+    "Name": "ErrorBadge",
+    "Tags": [
+      "x",
+      "warning",
+      "alert",
+      "problem",
+      "notification"
+    ]
+  },
+  {
+    "Code": "EA3A",
+    "Name": "CircleRing",
+    "Tags": [
+      "shape",
+      "geometry"
+    ]
+  },
+  {
+    "Code": "EA3B",
+    "Name": "CircleFill",
+    "Tags": [
+      "shape",
+      "geometry"
+    ]
+  },
+  {
+    "Code": "EA3C",
+    "Name": "MergeCall",
+    "Tags": [
+      "arrow",
+      "combine",
+      "conference",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EA3D",
+    "Name": "PrivateCall",
+    "Tags": [
+      "arrow",
+      "secure",
+      "confidential",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EA3F",
+    "Name": "Record2",
+    "Tags": [
+      "circle",
+      "control",
+      "playback",
+      "wait",
+      "stop",
+      "transcribe"
+    ]
+  },
+  {
+    "Code": "EA40",
+    "Name": "AllAppsMirrored",
+    "Tags": [
+      "plugin",
+      "square",
+      "stack"
+    ]
+  },
+  {
+    "Code": "EA41",
+    "Name": "BookmarksMirrored",
+    "Tags": [
+      "read",
+      "list",
+      "bullet points",
+      "formatting"
+    ]
+  },
+  {
+    "Code": "EA42",
+    "Name": "BulletedListMirrored",
+    "Tags": [
+      "organize",
+      "items",
+      "points"
+    ]
+  },
+  {
+    "Code": "EA43",
+    "Name": "CallForwardInternationalMirrored",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EA44",
+    "Name": "CallForwardRoamingMirrored",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EA47",
+    "Name": "ChromeBackMirrored",
+    "Tags": [
+      "arrow",
+      "back",
+      "navigate",
+      "browser"
+    ]
+  },
+  {
+    "Code": "EA48",
+    "Name": "ClearSelectionMirrored",
+    "Tags": [
+      "check",
+      "checkmark",
+      "check multiple"
+    ]
+  },
+  {
+    "Code": "EA49",
+    "Name": "ClosePaneMirrored",
+    "Tags": [
+      "sidebar",
+      "hide",
+      "exit",
+      "collapse"
+    ]
+  },
+  {
+    "Code": "EA4A",
+    "Name": "ContactInfoMirrored",
+    "Tags": [
+      "person",
+      "user",
+      "details"
+    ]
+  },
+  {
+    "Code": "EA4B",
+    "Name": "DockRightMirrored",
+    "Tags": [
+      "position",
+      "side",
+      "panel"
+    ]
+  },
+  {
+    "Code": "EA4C",
+    "Name": "DockLeftMirrored",
+    "Tags": [
+      "position",
+      "side",
+      "panel"
+    ]
+  },
+  {
+    "Code": "EA4E",
+    "Name": "ExpandTileMirrored",
+    "Tags": [
+      "maximize",
+      "view",
+      "window"
+    ]
+  },
+  {
+    "Code": "EA4F",
+    "Name": "GoMirrored",
+    "Tags": [
+      "arrow",
+      "start",
+      "move",
+      "launch",
+      "begin"
+    ]
+  },
+  {
+    "Code": "EA50",
+    "Name": "GripperResizeMirrored",
+    "Tags": [
+      "triangle",
+      "drag",
+      "handle"
+    ]
+  },
+  {
+    "Code": "EA51",
+    "Name": "HelpMirrored",
+    "Tags": [
+      "?",
+      "question",
+      "support",
+      "guide",
+      "assistance",
+      "info"
+    ]
+  },
+  {
+    "Code": "EA52",
+    "Name": "ImportMirrored",
+    "Tags": [
+      "arrow",
+      "upload",
+      "file",
+      "add",
+      "transfer"
+    ]
+  },
+  {
+    "Code": "EA53",
+    "Name": "ImportAllMirrored",
+    "Tags": [
+      "arrow",
+      "upload",
+      "file",
+      "add",
+      "transfer"
+    ]
+  },
+  {
+    "Code": "EA54",
+    "Name": "LeaveChatMirrored",
+    "Tags": [
+      "exit",
+      "leave",
+      "message",
+      "conversation",
+      "disconnect"
+    ]
+  },
+  {
+    "Code": "EA55",
+    "Name": "ListMirrored",
+    "Tags": [
+      "text",
+      "line",
+      "view"
+    ]
+  },
+  {
+    "Code": "EA56",
+    "Name": "MailForwardMirrored",
+    "Tags": [
+      "send",
+      "arrow",
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "letter"
+    ]
+  },
+  {
+    "Code": "EA57",
+    "Name": "MailReplyMirrored",
+    "Tags": [
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "respond",
+      "letter"
+    ]
+  },
+  {
+    "Code": "EA58",
+    "Name": "MailReplyAllMirrored",
+    "Tags": [
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "respond",
+      "letter"
+    ]
+  },
+  {
+    "Code": "EA5B",
+    "Name": "OpenPaneMirrored",
+    "Tags": [
+      "sidebar",
+      "expand",
+      "menu",
+      "show"
+    ]
+  },
+  {
+    "Code": "EA5C",
+    "Name": "OpenWithMirrored",
+    "Tags": [
+      "application",
+      "program",
+      "associate",
+      "file",
+      "choose",
+      "viewer"
+    ]
+  },
+  {
+    "Code": "EA5E",
+    "Name": "ParkingLocationMirrored",
+    "Tags": [
+      "car",
+      "spot",
+      "space"
+    ]
+  },
+  {
+    "Code": "EA5F",
+    "Name": "ResizeMouseMediumMirrored",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "EA60",
+    "Name": "ResizeMouseSmallMirrored",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "EA61",
+    "Name": "ResizeMouseTallMirrored",
+    "Tags": [
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "EA62",
+    "Name": "ResizeTouchNarrowerMirrored",
+    "Tags": [
+      "arrow",
+      "drag",
+      "resize",
+      "adjust",
+      "pointer",
+      "handle"
+    ]
+  },
+  {
+    "Code": "EA63",
+    "Name": "SendMirrored",
+    "Tags": [
+      "paper plane",
+      "mail",
+      "message",
+      "email"
+    ]
+  },
+  {
+    "Code": "EA64",
+    "Name": "SendFillMirrored",
+    "Tags": [
+      "paper plane",
+      "mail",
+      "message",
+      "email"
+    ]
+  },
+  {
+    "Code": "EA65",
+    "Name": "ShowResultsMirrored",
+    "Tags": [
+      "list",
+      "bullet points",
+      "formatting",
+      "display",
+      "view"
+    ]
+  },
+  {
+    "Code": "EA69",
+    "Name": "Media",
+    "Tags": [
+      "audio",
+      "video",
+      "content",
+      "entertainment",
+      "streaming"
+    ]
+  },
+  {
+    "Code": "EA6A",
+    "Name": "SyncError",
+    "Tags": [
+      "arrow",
+      "!",
+      "failure",
+      "problem",
+      "update"
+    ]
+  },
+  {
+    "Code": "EA6C",
+    "Name": "Devices3",
+    "Tags": [
+      "hardware",
+      "connections",
+      "peripherals",
+      "electronics",
+      "gadgets"
+    ]
+  },
+  {
+    "Code": "EA79",
+    "Name": "SlowMotionOn",
+    "Tags": [
+      "playback",
+      "video",
+      "effect",
+      "speed"
+    ]
+  },
+  {
+    "Code": "EA80",
+    "Name": "Lightbulb",
+    "Tags": [
+      "light",
+      "illuminate",
+      "knowledge",
+      "smart",
+      "idea",
+      "tip"
+    ]
+  },
+  {
+    "Code": "EA81",
+    "Name": "StatusCircle",
+    "Tags": [
+      "indicator",
+      "circle",
+      "check",
+      "signal"
+    ]
+  },
+  {
+    "Code": "EA82",
+    "Name": "StatusTriangle",
+    "Tags": [
+      "indicator",
+      "warning",
+      "alert"
+    ]
+  },
+  {
+    "Code": "EA83",
+    "Name": "StatusError",
+    "Tags": [
+      "x",
+      "problem",
+      "failure",
+      "alert"
+    ]
+  },
+  {
+    "Code": "EA84",
+    "Name": "StatusWarning",
+    "Tags": [
+      "!",
+      "caution",
+      "alert",
+      "attention"
+    ]
+  },
+  {
+    "Code": "EA85",
+    "Name": "VolumeDisabled",
+    "Tags": []
+  },
+  {
+    "Code": "EA86",
+    "Name": "Puzzle",
+    "Tags": [
+      "piece",
+      "game",
+      "solution",
+      "challenge"
+    ]
+  },
+  {
+    "Code": "EA89",
+    "Name": "CalendarSolid",
+    "Tags": [
+      "time",
+      "date",
+      "planning"
+    ]
+  },
+  {
+    "Code": "EA8A",
+    "Name": "HomeSolid",
+    "Tags": [
+      "house",
+      "safety",
+      "location",
+      "space",
+      "wfh"
+    ]
+  },
+  {
+    "Code": "EA8B",
+    "Name": "ParkingLocationSolid",
+    "Tags": [
+      "car",
+      "spot",
+      "space"
+    ]
+  },
+  {
+    "Code": "EA8C",
+    "Name": "ContactSolid",
+    "Tags": [
+      "person",
+      "user",
+      "details"
+    ]
+  },
+  {
+    "Code": "EA8D",
+    "Name": "ConstructionSolid",
+    "Tags": [
+      "person",
+      "user",
+      "work"
+    ]
+  },
+  {
+    "Code": "EA8E",
+    "Name": "AccidentSolid",
+    "Tags": [
+      "car"
+    ]
+  },
+  {
+    "Code": "EA8F",
+    "Name": "Ringer",
+    "Tags": [
+      "bell",
+      "notification",
+      "alert"
+    ]
+  },
+  {
+    "Code": "EA90",
+    "Name": "PDF",
+    "Tags": [
+      "document",
+      "file",
+      "portable",
+      "format",
+      "view"
+    ]
+  },
+  {
+    "Code": "EA91",
+    "Name": "ThoughtBubble",
+    "Tags": [
+      "cloud",
+      "idea",
+      "concept",
+      "conversation"
+    ]
+  },
+  {
+    "Code": "EA92",
+    "Name": "HeartBroken",
+    "Tags": [
+      "love",
+      "emotion",
+      "sadness",
+      "dislike"
+    ]
+  },
+  {
+    "Code": "EA93",
+    "Name": "BatteryCharging10",
+    "Tags": [
+      "power"
+    ]
+  },
+  {
+    "Code": "EA94",
+    "Name": "BatterySaver9",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EA95",
+    "Name": "BatterySaver10",
+    "Tags": [
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EA97",
+    "Name": "CallForwardingMirrored",
+    "Tags": [
+      "phone",
+      "handset",
+      "audio"
+    ]
+  },
+  {
+    "Code": "EA98",
+    "Name": "MultiSelectMirrored",
+    "Tags": [
+      "checkmark",
+      "task",
+      "list",
+      "type"
+    ]
+  },
+  {
+    "Code": "EA99",
+    "Name": "Broom",
+    "Tags": [
+      "sweep",
+      "clean",
+      "brush"
+    ]
+  },
+  {
+    "Code": "EAC2",
+    "Name": "ForwardCall",
+    "Tags": [
+      "arrow",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EAC7",
+    "Name": "DesktopLeafTwo",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EAD4",
+    "Name": "Emojiplay",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EAD5",
+    "Name": "EmojiBrush",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EAD6",
+    "Name": "EyeTracking",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EAD7",
+    "Name": "EyeTrackingText",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EADF",
+    "Name": "Trackers",
+    "Tags": [
+      "check",
+      "monitor",
+      "progress",
+      "list"
+    ]
+  },
+  {
+    "Code": "EAFC",
+    "Name": "Market",
+    "Tags": [
+      "arrow",
+      "stocks",
+      "finance",
+      "trading",
+      "investment"
+    ]
+  },
+  {
+    "Code": "EB05",
+    "Name": "PieSingle",
+    "Tags": [
+      "chart",
+      "graph",
+      "data",
+      "visual",
+      "analysis",
+      "statistics",
+      "representation"
+    ]
+  },
+  {
+    "Code": "EB0F",
+    "Name": "StockUp",
+    "Tags": [
+      "arrow",
+      "increase",
+      "growth",
+      "rise",
+      "market"
+    ]
+  },
+  {
+    "Code": "EB11",
+    "Name": "StockDown",
+    "Tags": [
+      "arrow",
+      "decrease",
+      "decline",
+      "fall",
+      "market"
+    ]
+  },
+  {
+    "Code": "EB19",
+    "Name": "ClicktoDoOff",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EB1D",
+    "Name": "ClicktoDo",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EB3B",
+    "Name": "GenericApp",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EB3C",
+    "Name": "Design",
+    "Tags": [
+      "ruler",
+      "triangle",
+      "measurement",
+      "drafting",
+      "geometry",
+      "sketch",
+      "precision"
+    ]
+  },
+  {
+    "Code": "EB41",
+    "Name": "Website",
+    "Tags": [
+      "web",
+      "internet",
+      "site",
+      "online",
+      "page"
+    ]
+  },
+  {
+    "Code": "EB42",
+    "Name": "Drop",
+    "Tags": [
+      "water",
+      "liquid",
+      "spill",
+      "paint"
+    ]
+  },
+  {
+    "Code": "EB44",
+    "Name": "Radar",
+    "Tags": [
+      "signal",
+      "tracking",
+      "detection",
+      "monitoring"
+    ]
+  },
+  {
+    "Code": "EB47",
+    "Name": "BusSolid",
+    "Tags": [
+      "vehicle",
+      "transportation",
+      "public",
+      "travel"
+    ]
+  },
+  {
+    "Code": "EB48",
+    "Name": "FerrySolid",
+    "Tags": [
+      "boat",
+      "ship",
+      "ocean",
+      "travel"
+    ]
+  },
+  {
+    "Code": "EB49",
+    "Name": "StartPointSolid",
+    "Tags": [
+      "map",
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "EB4A",
+    "Name": "StopPointSolid",
+    "Tags": [
+      "map",
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "EB4B",
+    "Name": "EndPointSolid",
+    "Tags": [
+      "flag",
+      "map",
+      "travel",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "EB4C",
+    "Name": "AirplaneSolid",
+    "Tags": [
+      "flight",
+      "vehicle",
+      "travel"
+    ]
+  },
+  {
+    "Code": "EB4D",
+    "Name": "TrainSolid",
+    "Tags": [
+      "rail",
+      "transport",
+      "travel",
+      "track",
+      "station"
+    ]
+  },
+  {
+    "Code": "EB4E",
+    "Name": "WorkSolid",
+    "Tags": [
+      "bag",
+      "handbag",
+      "briefcase",
+      "office"
+    ]
+  },
+  {
+    "Code": "EB4F",
+    "Name": "ReminderFill",
+    "Tags": [
+      "light",
+      "illuminate",
+      "knowledge",
+      "smart",
+      "idea",
+      "tip",
+      "alert",
+      "notification",
+      "task",
+      "prompt"
+    ]
+  },
+  {
+    "Code": "EB50",
+    "Name": "Reminder",
+    "Tags": [
+      "light",
+      "illuminate",
+      "knowledge",
+      "smart",
+      "idea",
+      "tip",
+      "alert",
+      "notification",
+      "task",
+      "prompt"
+    ]
+  },
+  {
+    "Code": "EB51",
+    "Name": "Heart",
+    "Tags": [
+      "love",
+      "emotion",
+      "like"
+    ]
+  },
+  {
+    "Code": "EB52",
+    "Name": "HeartFill",
+    "Tags": [
+      "love",
+      "emotion",
+      "like"
+    ]
+  },
+  {
+    "Code": "EB55",
+    "Name": "EthernetError",
+    "Tags": [
+      "x",
+      "network",
+      "connection",
+      "cable"
+    ]
+  },
+  {
+    "Code": "EB56",
+    "Name": "EthernetWarning",
+    "Tags": [
+      "!",
+      "network",
+      "connection",
+      "cable"
+    ]
+  },
+  {
+    "Code": "EB57",
+    "Name": "StatusConnecting1",
+    "Tags": [
+      "network",
+      "connection",
+      "loading"
+    ]
+  },
+  {
+    "Code": "EB58",
+    "Name": "StatusConnecting2",
+    "Tags": [
+      "network",
+      "connection",
+      "loading"
+    ]
+  },
+  {
+    "Code": "EB59",
+    "Name": "StatusUnsecure",
+    "Tags": [
+      "warning",
+      "connection",
+      "risk",
+      "alert",
+      "shield"
+    ]
+  },
+  {
+    "Code": "EB5A",
+    "Name": "WifiError0",
+    "Tags": [
+      "x",
+      "connection",
+      "failed",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB5B",
+    "Name": "WifiError1",
+    "Tags": [
+      "x",
+      "connection",
+      "failed",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB5C",
+    "Name": "WifiError2",
+    "Tags": [
+      "x",
+      "connection",
+      "failed",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB5D",
+    "Name": "WifiError3",
+    "Tags": [
+      "x",
+      "connection",
+      "failed",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB5E",
+    "Name": "WifiError4",
+    "Tags": [
+      "x",
+      "connection",
+      "failed",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB5F",
+    "Name": "WifiWarning0",
+    "Tags": [
+      "!",
+      "signal",
+      "connection",
+      "alert",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB60",
+    "Name": "WifiWarning1",
+    "Tags": [
+      "!",
+      "signal",
+      "connection",
+      "alert",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB61",
+    "Name": "WifiWarning2",
+    "Tags": [
+      "!",
+      "signal",
+      "connection",
+      "alert",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB62",
+    "Name": "WifiWarning3",
+    "Tags": [
+      "!",
+      "signal",
+      "connection",
+      "alert",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB63",
+    "Name": "WifiWarning4",
+    "Tags": [
+      "!",
+      "signal",
+      "connection",
+      "alert",
+      "network"
+    ]
+  },
+  {
+    "Code": "EB66",
+    "Name": "Devices4",
+    "Tags": [
+      "hardware",
+      "connections",
+      "peripherals",
+      "electronics",
+      "gadgets"
+    ]
+  },
+  {
+    "Code": "EB67",
+    "Name": "NUIIris",
+    "Tags": [
+      "eye",
+      "password"
+    ]
+  },
+  {
+    "Code": "EB68",
+    "Name": "NUIFace",
+    "Tags": [
+      "emoji",
+      "smiley"
+    ]
+  },
+  {
+    "Code": "EB77",
+    "Name": "GatewayRouter",
+    "Tags": [
+      "network",
+      "connection",
+      "internet"
+    ]
+  },
+  {
+    "Code": "EB7E",
+    "Name": "EditMirrored",
+    "Tags": [
+      "pencil",
+      "update",
+      "create",
+      "draw"
+    ]
+  },
+  {
+    "Code": "EB82",
+    "Name": "NUIFPStartSlideHand",
+    "Tags": []
+  },
+  {
+    "Code": "EB83",
+    "Name": "NUIFPStartSlideAction",
+    "Tags": []
+  },
+  {
+    "Code": "EB84",
+    "Name": "NUIFPContinueSlideHand",
+    "Tags": []
+  },
+  {
+    "Code": "EB85",
+    "Name": "NUIFPContinueSlideAction",
+    "Tags": []
+  },
+  {
+    "Code": "EB86",
+    "Name": "NUIFPRollRightHand",
+    "Tags": []
+  },
+  {
+    "Code": "EB87",
+    "Name": "NUIFPRollRightHandAction",
+    "Tags": []
+  },
+  {
+    "Code": "EB88",
+    "Name": "NUIFPRollLeftHand",
+    "Tags": []
+  },
+  {
+    "Code": "EB89",
+    "Name": "NUIFPRollLeftAction",
+    "Tags": []
+  },
+  {
+    "Code": "EB8A",
+    "Name": "NUIFPPressHand",
+    "Tags": []
+  },
+  {
+    "Code": "EB8B",
+    "Name": "NUIFPPressAction",
+    "Tags": []
+  },
+  {
+    "Code": "EB8C",
+    "Name": "NUIFPPressRepeatHand",
+    "Tags": []
+  },
+  {
+    "Code": "EB8D",
+    "Name": "NUIFPPressRepeatAction",
+    "Tags": []
+  },
+  {
+    "Code": "EB90",
+    "Name": "StatusErrorFull",
+    "Tags": [
+      "x",
+      "problem",
+      "failure",
+      "alert"
+    ]
+  },
+  {
+    "Code": "EB91",
+    "Name": "TaskViewExpanded",
+    "Tags": [
+      "overview",
+      "window"
+    ]
+  },
+  {
+    "Code": "EB95",
+    "Name": "Certificate",
+    "Tags": [
+      "diploma",
+      "education",
+      "ribbon"
+    ]
+  },
+  {
+    "Code": "EB96",
+    "Name": "BackSpaceQWERTYLg",
+    "Tags": [
+      "delete",
+      "backward",
+      "remove",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "EB97",
+    "Name": "ReturnKeyLg",
+    "Tags": [
+      "arrow",
+      "enter",
+      "submit",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "EB9D",
+    "Name": "FastForward",
+    "Tags": [
+      "video",
+      "speed",
+      "arrow"
+    ]
+  },
+  {
+    "Code": "EB9E",
+    "Name": "Rewind",
+    "Tags": [
+      "control",
+      "playback",
+      "back"
+    ]
+  },
+  {
+    "Code": "EB9F",
+    "Name": "Photo2",
+    "Tags": [
+      "image",
+      "picture",
+      "snapshot",
+      "portrait",
+      "frame",
+      "gallery",
+      "canvas",
+      "visual",
+      "view"
+    ]
+  },
+  {
+    "Code": "EBA0",
+    "Name": "MobBattery0",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA1",
+    "Name": "MobBattery1",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA2",
+    "Name": "MobBattery2",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA3",
+    "Name": "MobBattery3",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA4",
+    "Name": "MobBattery4",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA5",
+    "Name": "MobBattery5",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA6",
+    "Name": "MobBattery6",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA7",
+    "Name": "MobBattery7",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA8",
+    "Name": "MobBattery8",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBA9",
+    "Name": "MobBattery9",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBAA",
+    "Name": "MobBattery10",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBAB",
+    "Name": "MobBatteryCharging0",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBAC",
+    "Name": "MobBatteryCharging1",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBAD",
+    "Name": "MobBatteryCharging2",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBAE",
+    "Name": "MobBatteryCharging3",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBAF",
+    "Name": "MobBatteryCharging4",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB0",
+    "Name": "MobBatteryCharging5",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB1",
+    "Name": "MobBatteryCharging6",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB2",
+    "Name": "MobBatteryCharging7",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB3",
+    "Name": "MobBatteryCharging8",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB4",
+    "Name": "MobBatteryCharging9",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB5",
+    "Name": "MobBatteryCharging10",
+    "Tags": [
+      "phone",
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "EBB6",
+    "Name": "MobBatterySaver0",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBB7",
+    "Name": "MobBatterySaver1",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBB8",
+    "Name": "MobBatterySaver2",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBB9",
+    "Name": "MobBatterySaver3",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBBA",
+    "Name": "MobBatterySaver4",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBBB",
+    "Name": "MobBatterySaver5",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBBC",
+    "Name": "MobBatterySaver6",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBBD",
+    "Name": "MobBatterySaver7",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBBE",
+    "Name": "MobBatterySaver8",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBBF",
+    "Name": "MobBatterySaver9",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBC0",
+    "Name": "MobBatterySaver10",
+    "Tags": [
+      "phone",
+      "charge",
+      "power",
+      "eco friendly"
+    ]
+  },
+  {
+    "Code": "EBC3",
+    "Name": "DictionaryCloud",
+    "Tags": [
+      "book",
+      "reference",
+      "storage",
+      "upload",
+      "download",
+      "save",
+      "sync",
+      "remote"
+    ]
+  },
+  {
+    "Code": "EBC4",
+    "Name": "ResetDrive",
+    "Tags": [
+      "storage",
+      "reboot",
+      "refresh"
+    ]
+  },
+  {
+    "Code": "EBC5",
+    "Name": "VolumeBars",
+    "Tags": [
+      "sound",
+      "level",
+      "audio"
+    ]
+  },
+  {
+    "Code": "EBC6",
+    "Name": "Project",
+    "Tags": [
+      "present",
+      "presentation",
+      "view",
+      "slide",
+      "lecture"
+    ]
+  },
+  {
+    "Code": "EBD2",
+    "Name": "AdjustHologram",
+    "Tags": [
+      "3D",
+      "cube",
+      "projection",
+      "virtual",
+      "illusion",
+      "tech",
+      "interactive"
+    ]
+  },
+  {
+    "Code": "EBD3",
+    "Name": "CloudDownload",
+    "Tags": [
+      "storage",
+      "upload",
+      "save",
+      "sync",
+      "remote"
+    ]
+  },
+  {
+    "Code": "EBD4",
+    "Name": "MobWifiCallBars",
+    "Tags": [
+      "signal",
+      "network"
+    ]
+  },
+  {
+    "Code": "EBD5",
+    "Name": "MobWifiCall0",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EBD6",
+    "Name": "MobWifiCall1",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EBD7",
+    "Name": "MobWifiCall2",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EBD8",
+    "Name": "MobWifiCall3",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EBD9",
+    "Name": "MobWifiCall4",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EBDA",
+    "Name": "Family",
+    "Tags": [
+      "people",
+      "person",
+      "user"
+    ]
+  },
+  {
+    "Code": "EBDB",
+    "Name": "LockFeedback",
+    "Tags": [
+      "message"
+    ]
+  },
+  {
+    "Code": "EBDE",
+    "Name": "DeviceDiscovery",
+    "Tags": [
+      "search",
+      "scan",
+      "connect",
+      "network",
+      "pair"
+    ]
+  },
+  {
+    "Code": "EBE6",
+    "Name": "WindDirection",
+    "Tags": [
+      "weather",
+      "compass",
+      "forecast",
+      "breeze",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "EBE7",
+    "Name": "RightArrowKeyTime0",
+    "Tags": [
+      "navigate",
+      "forward",
+      "progress"
+    ]
+  },
+  {
+    "Code": "EBE8",
+    "Name": "Bug",
+    "Tags": [
+      "error",
+      "debug",
+      "issue",
+      "problem",
+      "glitch",
+      "software",
+      "report",
+      "code"
+    ]
+  },
+  {
+    "Code": "EBFC",
+    "Name": "TabletMode",
+    "Tags": [
+      "touchscreen",
+      "convertible",
+      "device"
+    ]
+  },
+  {
+    "Code": "EBFD",
+    "Name": "StatusCircleLeft",
+    "Tags": [
+      "indicator",
+      "progress"
+    ]
+  },
+  {
+    "Code": "EBFE",
+    "Name": "StatusTriangleLeft",
+    "Tags": [
+      "indicator",
+      "progress",
+      "alert",
+      "warning"
+    ]
+  },
+  {
+    "Code": "EBFF",
+    "Name": "StatusErrorLeft",
+    "Tags": [
+      "x",
+      "indicator",
+      "progress",
+      "problem",
+      "issue"
+    ]
+  },
+  {
+    "Code": "EC00",
+    "Name": "StatusWarningLeft",
+    "Tags": [
+      "!",
+      "indicator",
+      "progress",
+      "caution",
+      "attention"
+    ]
+  },
+  {
+    "Code": "EC02",
+    "Name": "MobBatteryUnknown",
+    "Tags": [
+      "charge",
+      "power",
+      "status",
+      "phone"
+    ]
+  },
+  {
+    "Code": "EC05",
+    "Name": "NetworkTower",
+    "Tags": [
+      "signal",
+      "cell",
+      "communication",
+      "coverage",
+      "internet"
+    ]
+  },
+  {
+    "Code": "EC06",
+    "Name": "CityNext",
+    "Tags": [
+      "building",
+      "skyline",
+      "urban",
+      "metropolis",
+      "architecture",
+      "downtown"
+    ]
+  },
+  {
+    "Code": "EC07",
+    "Name": "CityNext2",
+    "Tags": [
+      "building",
+      "skyline",
+      "urban",
+      "metropolis",
+      "architecture",
+      "downtown"
+    ]
+  },
+  {
+    "Code": "EC08",
+    "Name": "Courthouse",
+    "Tags": [
+      "law",
+      "government",
+      "justice",
+      "court",
+      "legal",
+      "building"
+    ]
+  },
+  {
+    "Code": "EC09",
+    "Name": "Groceries",
+    "Tags": []
+  },
+  {
+    "Code": "EC0A",
+    "Name": "Sustainable",
+    "Tags": [
+      "leaf",
+      "green",
+      "power",
+      "eco friendly",
+      "renewable"
+    ]
+  },
+  {
+    "Code": "EC0B",
+    "Name": "BuildingEnergy",
+    "Tags": [
+      "sustainability",
+      "efficiency",
+      "green",
+      "power",
+      "eco friendly",
+      "renewable"
+    ]
+  },
+  {
+    "Code": "EC11",
+    "Name": "ToggleFilled",
+    "Tags": [
+      "switch",
+      "on",
+      "active"
+    ]
+  },
+  {
+    "Code": "EC12",
+    "Name": "ToggleBorder",
+    "Tags": [
+      "switch",
+      "off",
+      "inactive"
+    ]
+  },
+  {
+    "Code": "EC13",
+    "Name": "SliderThumb",
+    "Tags": [
+      "control",
+      "handle",
+      "adjust"
+    ]
+  },
+  {
+    "Code": "EC14",
+    "Name": "ToggleThumb",
+    "Tags": [
+      "circle",
+      "switch",
+      "knob",
+      "control"
+    ]
+  },
+  {
+    "Code": "EC15",
+    "Name": "MiracastLogoSmall",
+    "Tags": [
+      "wireless",
+      "display",
+      "screen"
+    ]
+  },
+  {
+    "Code": "EC16",
+    "Name": "MiracastLogoLarge",
+    "Tags": [
+      "wireless",
+      "display",
+      "screen"
+    ]
+  },
+  {
+    "Code": "EC19",
+    "Name": "PLAP",
+    "Tags": [
+      "lock",
+      "key",
+      "security",
+      "access",
+      "safety",
+      "permission",
+      "access",
+      "protection",
+      "password"
+    ]
+  },
+  {
+    "Code": "EC1B",
+    "Name": "Badge",
+    "Tags": [
+      "badge",
+      "award",
+      "achievement",
+      "medal",
+      "recognition"
+    ]
+  },
+  {
+    "Code": "EC1E",
+    "Name": "SignalRoaming",
+    "Tags": [
+      "triangle",
+      "network",
+      "coverage",
+      "mobile"
+    ]
+  },
+  {
+    "Code": "EC20",
+    "Name": "MobileLocked",
+    "Tags": [
+      "security",
+      "phone",
+      "device",
+      "protection",
+      "restricted"
+    ]
+  },
+  {
+    "Code": "EC24",
+    "Name": "InsiderHubApp",
+    "Tags": [
+      "announcement",
+      "beta",
+      "program",
+      "preview",
+      "early access"
+    ]
+  },
+  {
+    "Code": "EC25",
+    "Name": "PersonalFolder",
+    "Tags": [
+      "user",
+      "documents",
+      "files",
+      "storage",
+      "private",
+      "directory"
+    ]
+  },
+  {
+    "Code": "EC26",
+    "Name": "HomeGroup",
+    "Tags": [
+      "network",
+      "sharing",
+      "devices",
+      "chemical",
+      "formaldehyde"
+    ]
+  },
+  {
+    "Code": "EC27",
+    "Name": "MyNetwork",
+    "Tags": [
+      "connection",
+      "devices",
+      "shared",
+      "local"
+    ]
+  },
+  {
+    "Code": "EC31",
+    "Name": "KeyboardFull",
+    "Tags": [
+      "keyboard",
+      "type",
+      "key",
+      "device"
+    ]
+  },
+  {
+    "Code": "EC32",
+    "Name": "Cafe",
+    "Tags": [
+      "coffee",
+      "cup",
+      "restaurant",
+      "beverage",
+      "break",
+      "snack"
+    ]
+  },
+  {
+    "Code": "EC34",
+    "Name": "FormatText",
+    "Tags": []
+  },
+  {
+    "Code": "EC37",
+    "Name": "MobSignal1",
+    "Tags": [
+      "bar",
+      "network",
+      "coverage",
+      "cellular"
+    ]
+  },
+  {
+    "Code": "EC38",
+    "Name": "MobSignal2",
+    "Tags": [
+      "bar",
+      "network",
+      "coverage",
+      "cellular"
+    ]
+  },
+  {
+    "Code": "EC39",
+    "Name": "MobSignal3",
+    "Tags": [
+      "bar",
+      "network",
+      "coverage",
+      "cellular"
+    ]
+  },
+  {
+    "Code": "EC3A",
+    "Name": "MobSignal4",
+    "Tags": [
+      "bar",
+      "network",
+      "coverage",
+      "cellular"
+    ]
+  },
+  {
+    "Code": "EC3B",
+    "Name": "MobSignal5",
+    "Tags": [
+      "bar",
+      "network",
+      "coverage",
+      "cellular"
+    ]
+  },
+  {
+    "Code": "EC3C",
+    "Name": "MobWifi1",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "EC3D",
+    "Name": "MobWifi2",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "EC3E",
+    "Name": "MobWifi3",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "EC3F",
+    "Name": "MobWifi4",
+    "Tags": [
+      "wireless fidelity",
+      "connect",
+      "internet",
+      "web",
+      "connection",
+      "network"
+    ]
+  },
+  {
+    "Code": "EC40",
+    "Name": "MobAirplane",
+    "Tags": [
+      "flight",
+      "vehicle",
+      "travel"
+    ]
+  },
+  {
+    "Code": "EC41",
+    "Name": "MobBluetooth",
+    "Tags": [
+      "device",
+      "connection"
+    ]
+  },
+  {
+    "Code": "EC42",
+    "Name": "MobActionCenter",
+    "Tags": [
+      "message",
+      "notification"
+    ]
+  },
+  {
+    "Code": "EC43",
+    "Name": "MobLocation",
+    "Tags": [
+      "pin",
+      "marker",
+      "map",
+      "travel"
+    ]
+  },
+  {
+    "Code": "EC44",
+    "Name": "MobWifiHotspot",
+    "Tags": [
+      "connection",
+      "network",
+      "share",
+      "network"
+    ]
+  },
+  {
+    "Code": "EC45",
+    "Name": "LanguageJpn",
+    "Tags": [
+      "japanese",
+      "Kanji",
+      "character",
+      "language"
+    ]
+  },
+  {
+    "Code": "EC46",
+    "Name": "MobQuietHours",
+    "Tags": [
+      "moon",
+      "night"
+    ]
+  },
+  {
+    "Code": "EC47",
+    "Name": "MobDrivingMode",
+    "Tags": [
+      "car"
+    ]
+  },
+  {
+    "Code": "EC48",
+    "Name": "SpeedOff",
+    "Tags": [
+      "disabled",
+      "inactive",
+      "pause",
+      "performance"
+    ]
+  },
+  {
+    "Code": "EC49",
+    "Name": "SpeedMedium",
+    "Tags": [
+      "average",
+      "moderate",
+      "balance",
+      "performance"
+    ]
+  },
+  {
+    "Code": "EC4A",
+    "Name": "SpeedHigh",
+    "Tags": [
+      "fast",
+      "quick",
+      "maximum",
+      "performance"
+    ]
+  },
+  {
+    "Code": "EC4E",
+    "Name": "ThisPC",
+    "Tags": [
+      "computer",
+      "device",
+      "files",
+      "explorer",
+      "desktop"
+    ]
+  },
+  {
+    "Code": "EC4F",
+    "Name": "MusicNote",
+    "Tags": [
+      "concert",
+      "musician",
+      "art",
+      "event"
+    ]
+  },
+  {
+    "Code": "EC50",
+    "Name": "FileExplorer",
+    "Tags": [
+      "application",
+      "manager",
+      "browser",
+      "documents",
+      "folder"
+    ]
+  },
+  {
+    "Code": "EC51",
+    "Name": "FileExplorerApp",
+    "Tags": [
+      "application",
+      "manager",
+      "browser",
+      "documents",
+      "folder"
+    ]
+  },
+  {
+    "Code": "EC52",
+    "Name": "LeftArrowKeyTime0",
+    "Tags": [
+      "navigation",
+      "previous",
+      "rewind"
+    ]
+  },
+  {
+    "Code": "EC54",
+    "Name": "MicOff",
+    "Tags": [
+      "microphone",
+      "mute",
+      "audio",
+      "silent",
+      "disabled"
+    ]
+  },
+  {
+    "Code": "EC55",
+    "Name": "MicSleep",
+    "Tags": [
+      "microphone",
+      "audio",
+      "idle",
+      "standby",
+      "inactive"
+    ]
+  },
+  {
+    "Code": "EC56",
+    "Name": "MicError",
+    "Tags": [
+      "x",
+      "microphone",
+      "audio",
+      "issue",
+      "fault",
+      "problem"
+    ]
+  },
+  {
+    "Code": "EC57",
+    "Name": "PlaybackRate1x",
+    "Tags": [
+      "normal",
+      "speed",
+      "video",
+      "audio",
+      "standard"
+    ]
+  },
+  {
+    "Code": "EC58",
+    "Name": "PlaybackRateOther",
+    "Tags": [
+      "normal",
+      "speed",
+      "video",
+      "audio",
+      "standard"
+    ]
+  },
+  {
+    "Code": "EC59",
+    "Name": "CashDrawer",
+    "Tags": [
+      "register",
+      "money",
+      "payment",
+      "transaction",
+      "pointofsale"
+    ]
+  },
+  {
+    "Code": "EC5A",
+    "Name": "BarcodeScanner",
+    "Tags": [
+      "inventory",
+      "product",
+      "retail",
+      "checkout",
+      "pointofsale"
+    ]
+  },
+  {
+    "Code": "EC5B",
+    "Name": "ReceiptPrinter",
+    "Tags": [
+      "paper",
+      "receiptpaper",
+      "transaction",
+      "purchase",
+      "sale",
+      "pointofsale"
+    ]
+  },
+  {
+    "Code": "EC5C",
+    "Name": "MagStripeReader",
+    "Tags": [
+      "card",
+      "payment",
+      "swipe",
+      "transaction"
+    ]
+  },
+  {
+    "Code": "EC61",
+    "Name": "CompletedSolid",
+    "Tags": [
+      "check",
+      "finished",
+      "done",
+      "achieved",
+      "success"
+    ]
+  },
+  {
+    "Code": "EC64",
+    "Name": "CompanionApp",
+    "Tags": [
+      "check"
+    ]
+  },
+  {
+    "Code": "EC6C",
+    "Name": "Favicon2",
+    "Tags": [
+      "logo",
+      "icon",
+      "brand",
+      "shortcut",
+      "symbol"
+    ]
+  },
+  {
+    "Code": "EC6D",
+    "Name": "SwipeRevealArt",
+    "Tags": []
+  },
+  {
+    "Code": "EC71",
+    "Name": "MicOn",
+    "Tags": [
+      "microphone",
+      "audio",
+      "active",
+      "sound",
+      "enabled",
+      "recording"
+    ]
+  },
+  {
+    "Code": "EC72",
+    "Name": "MicClipping",
+    "Tags": [
+      "microphone",
+      "audio",
+      "distortion",
+      "overload",
+      "volume",
+      "peak"
+    ]
+  },
+  {
+    "Code": "EC74",
+    "Name": "TabletSelected",
+    "Tags": [
+      "device",
+      "touchscreen",
+      "display",
+      "checked"
+    ]
+  },
+  {
+    "Code": "EC75",
+    "Name": "MobileSelected",
+    "Tags": [
+      "phone",
+      "smartphone",
+      "device",
+      "checked"
+    ]
+  },
+  {
+    "Code": "EC76",
+    "Name": "LaptopSelected",
+    "Tags": [
+      "notebook",
+      "device",
+      "portable",
+      "checked"
+    ]
+  },
+  {
+    "Code": "EC77",
+    "Name": "TVMonitorSelected",
+    "Tags": [
+      "selected",
+      "display",
+      "screen",
+      "checked"
+    ]
+  },
+  {
+    "Code": "EC7A",
+    "Name": "DeveloperTools",
+    "Tags": [
+      "debugging",
+      "coding",
+      "software"
+    ]
+  },
+  {
+    "Code": "EC7E",
+    "Name": "MobCallForwarding",
+    "Tags": [
+      "phone",
+      "handset",
+      "audio"
+    ]
+  },
+  {
+    "Code": "EC7F",
+    "Name": "MobCallForwardingMirrored",
+    "Tags": [
+      "phone",
+      "handset",
+      "audio"
+    ]
+  },
+  {
+    "Code": "EC80",
+    "Name": "BodyCam",
+    "Tags": [
+      "camera",
+      "body",
+      "recording",
+      "security"
+    ]
+  },
+  {
+    "Code": "EC81",
+    "Name": "PoliceCar",
+    "Tags": [
+      "vehicle",
+      "emergency",
+      "law"
+    ]
+  },
+  {
+    "Code": "EC83",
+    "Name": "UpdateStatusDot2",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EC87",
+    "Name": "Draw",
+    "Tags": [
+      "edit",
+      "create",
+      "pencil"
+    ]
+  },
+  {
+    "Code": "EC88",
+    "Name": "DrawSolid",
+    "Tags": [
+      "edit",
+      "create",
+      "pencil"
+    ]
+  },
+  {
+    "Code": "EC8A",
+    "Name": "LowerBrightness",
+    "Tags": [
+      "sun",
+      "day"
+    ]
+  },
+  {
+    "Code": "EC8F",
+    "Name": "ScrollUpDown",
+    "Tags": [
+      "navigate",
+      "vertical",
+      "move"
+    ]
+  },
+  {
+    "Code": "EC91",
+    "Name": "Uninstall",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EC92",
+    "Name": "DateTime",
+    "Tags": [
+      "planning"
+    ]
+  },
+  {
+    "Code": "EC94",
+    "Name": "HoloLens",
+    "Tags": [
+      "augmented",
+      "reality",
+      "mixed",
+      "virtual",
+      "headset"
+    ]
+  },
+  {
+    "Code": "EC9C",
+    "Name": "CloudNotSynced",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "ECA5",
+    "Name": "Tiles",
+    "Tags": [
+      "grid",
+      "layout",
+      "dashboard",
+      "pattern"
+    ]
+  },
+  {
+    "Code": "ECA7",
+    "Name": "PartyLeader",
+    "Tags": [
+      "person",
+      "user",
+      "Badge"
+    ]
+  },
+  {
+    "Code": "ECAA",
+    "Name": "AppIconDefault",
+    "Tags": [
+      "application"
+    ]
+  },
+  {
+    "Code": "ECAD",
+    "Name": "Calories",
+    "Tags": [
+      "fire"
+    ]
+  },
+  {
+    "Code": "ECAF",
+    "Name": "POI",
+    "Tags": [
+      "Point",
+      "Interest",
+      "location",
+      "landmark",
+      "destination",
+      "map"
+    ]
+  },
+  {
+    "Code": "ECB9",
+    "Name": "BandBattery0",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECBA",
+    "Name": "BandBattery1",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECBB",
+    "Name": "BandBattery2",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECBC",
+    "Name": "BandBattery3",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECBD",
+    "Name": "BandBattery4",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECBE",
+    "Name": "BandBattery5",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECBF",
+    "Name": "BandBattery6",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "ECC4",
+    "Name": "AddSurfaceHub",
+    "Tags": [
+      "+",
+      "device",
+      "physical",
+      "product",
+      "screen",
+      "touch screen",
+      "presentation"
+    ]
+  },
+  {
+    "Code": "ECC5",
+    "Name": "DevUpdate",
+    "Tags": [
+      "arrow",
+      "clock",
+      "time"
+    ]
+  },
+  {
+    "Code": "ECC6",
+    "Name": "Unit",
+    "Tags": [
+      "ruler"
+    ]
+  },
+  {
+    "Code": "ECC8",
+    "Name": "AddTo",
+    "Tags": [
+      "+",
+      "new",
+      "create"
+    ]
+  },
+  {
+    "Code": "ECC9",
+    "Name": "RemoveFrom",
+    "Tags": [
+      "-",
+      "delete"
+    ]
+  },
+  {
+    "Code": "ECCA",
+    "Name": "RadioBtnOff",
+    "Tags": [
+      "dot",
+      "circle"
+    ]
+  },
+  {
+    "Code": "ECCB",
+    "Name": "RadioBtnOn",
+    "Tags": [
+      "dot",
+      "circle",
+      "selected"
+    ]
+  },
+  {
+    "Code": "ECCC",
+    "Name": "RadioBullet2",
+    "Tags": [
+      "dot",
+      "circle"
+    ]
+  },
+  {
+    "Code": "ECCD",
+    "Name": "ExploreContent",
+    "Tags": [
+      "+",
+      "discover",
+      "browse",
+      "navigate"
+    ]
+  },
+  {
+    "Code": "ECE4",
+    "Name": "Blocked2",
+    "Tags": [
+      "-"
+    ]
+  },
+  {
+    "Code": "ECE7",
+    "Name": "ScrollMode",
+    "Tags": [
+      "movement",
+      "vertical",
+      "navigate"
+    ]
+  },
+  {
+    "Code": "ECE8",
+    "Name": "ZoomMode",
+    "Tags": [
+      "+",
+      "-",
+      "shrink",
+      "scale"
+    ]
+  },
+  {
+    "Code": "ECE9",
+    "Name": "PanMode",
+    "Tags": [
+      "window",
+      "view",
+      "layout",
+      "section"
+    ]
+  },
+  {
+    "Code": "ECF0",
+    "Name": "WiredUSB",
+    "Tags": [
+      "USB",
+      "cable",
+      "connection",
+      "port"
+    ]
+  },
+  {
+    "Code": "ECF1",
+    "Name": "WirelessUSB",
+    "Tags": [
+      "USB",
+      "bluetooth",
+      "connection",
+      "adapter",
+      "port"
+    ]
+  },
+  {
+    "Code": "ECF3",
+    "Name": "USBSafeConnect",
+    "Tags": [
+      "USB",
+      "secure",
+      "connect",
+      "protection"
+    ]
+  },
+  {
+    "Code": "ED0C",
+    "Name": "ActionCenterNotificationMirrored",
+    "Tags": [
+      "message",
+      "alert",
+      "reminder",
+      "warning",
+      "update"
+    ]
+  },
+  {
+    "Code": "ED0D",
+    "Name": "ActionCenterMirrored",
+    "Tags": [
+      "message",
+      "notification",
+      "chat"
+    ]
+  },
+  {
+    "Code": "ED0E",
+    "Name": "SubscriptionAdd",
+    "Tags": [
+      "+"
+    ]
+  },
+  {
+    "Code": "ED10",
+    "Name": "ResetDevice",
+    "Tags": [
+      "factoryreset",
+      "reboot",
+      "restore",
+      "restart",
+      "settings"
+    ]
+  },
+  {
+    "Code": "ED11",
+    "Name": "SubscriptionAddMirrored",
+    "Tags": [
+      "+"
+    ]
+  },
+  {
+    "Code": "ED14",
+    "Name": "QRCode",
+    "Tags": [
+      "scanner",
+      "barcode",
+      "matrix"
+    ]
+  },
+  {
+    "Code": "ED15",
+    "Name": "Feedback",
+    "Tags": [
+      "person",
+      "user"
+    ]
+  },
+  {
+    "Code": "ED1A",
+    "Name": "Hide",
+    "Tags": [
+      "eye",
+      "password",
+      "conceal",
+      "view",
+      "privacy"
+    ]
+  },
+  {
+    "Code": "ED1E",
+    "Name": "Subtitles",
+    "Tags": [
+      "caption",
+      "text",
+      "dialogue",
+      "speech",
+      "language",
+      "cc"
+    ]
+  },
+  {
+    "Code": "ED1F",
+    "Name": "SubtitlesAudio",
+    "Tags": [
+      "caption",
+      "text",
+      "dialogue",
+      "speech",
+      "language",
+      "cc"
+    ]
+  },
+  {
+    "Code": "ED21",
+    "Name": "RestartUpdate2",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "ED25",
+    "Name": "OpenFolderHorizontal",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "ED28",
+    "Name": "CalendarMirrored",
+    "Tags": [
+      "time",
+      "date",
+      "planning"
+    ]
+  },
+  {
+    "Code": "ED2A",
+    "Name": "MobeSIM",
+    "Tags": [
+      "mobile",
+      "network",
+      "cellular",
+      "status"
+    ]
+  },
+  {
+    "Code": "ED2B",
+    "Name": "MobeSIMNoProfile",
+    "Tags": [
+      "mobile",
+      "network",
+      "cellular",
+      "status"
+    ]
+  },
+  {
+    "Code": "ED2C",
+    "Name": "MobeSIMLocked",
+    "Tags": [
+      "mobile",
+      "network",
+      "cellular",
+      "status"
+    ]
+  },
+  {
+    "Code": "ED2D",
+    "Name": "MobeSIMBusy",
+    "Tags": [
+      "mobile",
+      "network",
+      "cellular",
+      "status"
+    ]
+  },
+  {
+    "Code": "ED2E",
+    "Name": "SignalError",
+    "Tags": [
+      "x",
+      "SIM",
+      "mobile",
+      "network",
+      "cellular",
+      "status"
+    ]
+  },
+  {
+    "Code": "ED2F",
+    "Name": "StreamingEnterprise",
+    "Tags": [
+      "media",
+      "live",
+      "video",
+      "online",
+      "work",
+      "business"
+    ]
+  },
+  {
+    "Code": "ED30",
+    "Name": "Headphone0",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume",
+      "device"
+    ]
+  },
+  {
+    "Code": "ED31",
+    "Name": "Headphone1",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume",
+      "device"
+    ]
+  },
+  {
+    "Code": "ED32",
+    "Name": "Headphone2",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume",
+      "device"
+    ]
+  },
+  {
+    "Code": "ED33",
+    "Name": "Headphone3",
+    "Tags": [
+      "audio",
+      "sound",
+      "volume",
+      "device"
+    ]
+  },
+  {
+    "Code": "ED35",
+    "Name": "Apps",
+    "Tags": [
+      "applications"
+    ]
+  },
+  {
+    "Code": "ED39",
+    "Name": "KeyboardBrightness",
+    "Tags": [
+      "keyboard",
+      "light",
+      "control",
+      "adjust"
+    ]
+  },
+  {
+    "Code": "ED3A",
+    "Name": "KeyboardLowerBrightness",
+    "Tags": [
+      "keyboard",
+      "light",
+      "control",
+      "adjust"
+    ]
+  },
+  {
+    "Code": "ED3C",
+    "Name": "SkipBack10",
+    "Tags": [
+      "number",
+      "seek",
+      "time",
+      "navigation",
+      "media",
+      "video"
+    ]
+  },
+  {
+    "Code": "ED3D",
+    "Name": "SkipForward30",
+    "Tags": [
+      "number",
+      "seek",
+      "time",
+      "navigation",
+      "media",
+      "video"
+    ]
+  },
+  {
+    "Code": "ED41",
+    "Name": "TreeFolderFolder",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "ED42",
+    "Name": "TreeFolderFolderFill",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "ED43",
+    "Name": "TreeFolderFolderOpen",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "ED44",
+    "Name": "TreeFolderFolderOpenFill",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "ED47",
+    "Name": "MultimediaDMP",
+    "Tags": [
+      "device",
+      "playback",
+      "streaming",
+      "content",
+      "network"
+    ]
+  },
+  {
+    "Code": "ED4C",
+    "Name": "KeyboardOneHanded",
+    "Tags": [
+      "typing",
+      "compact",
+      "mobile",
+      "input",
+      "ergonomic"
+    ]
+  },
+  {
+    "Code": "ED4D",
+    "Name": "Narrator",
+    "Tags": [
+      "accessibility",
+      "voice",
+      "audio",
+      "screen",
+      "reader",
+      "text",
+      "assistive"
+    ]
+  },
+  {
+    "Code": "ED53",
+    "Name": "EmojiTabPeople",
+    "Tags": [
+      "face",
+      "expressions",
+      "emotions",
+      "human"
+    ]
+  },
+  {
+    "Code": "ED54",
+    "Name": "EmojiTabSmilesAnimals",
+    "Tags": [
+      "face",
+      "smiley",
+      "cute",
+      "pets",
+      "happy"
+    ]
+  },
+  {
+    "Code": "ED55",
+    "Name": "EmojiTabCelebrationObjects",
+    "Tags": [
+      "balloon",
+      "party",
+      "objects",
+      "festive",
+      "joy"
+    ]
+  },
+  {
+    "Code": "ED56",
+    "Name": "EmojiTabFoodPlants",
+    "Tags": [
+      "pizza",
+      "meals"
+    ]
+  },
+  {
+    "Code": "ED57",
+    "Name": "EmojiTabTransitPlaces",
+    "Tags": [
+      "car",
+      "places",
+      "travel",
+      "locations",
+      "journey"
+    ]
+  },
+  {
+    "Code": "ED58",
+    "Name": "EmojiTabSymbols",
+    "Tags": [
+      "shapes",
+      "icons",
+      "signs",
+      "patterns"
+    ]
+  },
+  {
+    "Code": "ED59",
+    "Name": "EmojiTabTextSmiles",
+    "Tags": [
+      "faces",
+      "emotions",
+      "characters"
+    ]
+  },
+  {
+    "Code": "ED5A",
+    "Name": "EmojiTabFavorites",
+    "Tags": [
+      "clock",
+      "saved",
+      "liked",
+      "common"
+    ]
+  },
+  {
+    "Code": "ED5B",
+    "Name": "EmojiSwatch",
+    "Tags": [
+      "circle",
+      "colors",
+      "palette",
+      "emoji",
+      "design"
+    ]
+  },
+  {
+    "Code": "ED5C",
+    "Name": "ConnectApp",
+    "Tags": [
+      "pair",
+      "devices"
+    ]
+  },
+  {
+    "Code": "ED5D",
+    "Name": "CompanionDeviceFramework",
+    "Tags": [
+      "lock",
+      "connection",
+      "integration"
+    ]
+  },
+  {
+    "Code": "ED5E",
+    "Name": "Ruler",
+    "Tags": [
+      "measure",
+      "length",
+      "straight",
+      "tool",
+      "precision"
+    ]
+  },
+  {
+    "Code": "ED5F",
+    "Name": "FingerInking",
+    "Tags": [
+      "touch",
+      "draw",
+      "handwriting",
+      "ink",
+      "gesture"
+    ]
+  },
+  {
+    "Code": "ED60",
+    "Name": "StrokeErase",
+    "Tags": [
+      "delete",
+      "drawing",
+      "line",
+      "correction"
+    ]
+  },
+  {
+    "Code": "ED61",
+    "Name": "PointErase",
+    "Tags": [
+      "remove",
+      "spot",
+      "dot",
+      "edit"
+    ]
+  },
+  {
+    "Code": "ED62",
+    "Name": "ClearAllInk",
+    "Tags": [
+      "reset",
+      "erase",
+      "drawing"
+    ]
+  },
+  {
+    "Code": "ED63",
+    "Name": "Pencil",
+    "Tags": [
+      "write",
+      "draw",
+      "sketch",
+      "tool",
+      "creative"
+    ]
+  },
+  {
+    "Code": "ED64",
+    "Name": "Marker",
+    "Tags": [
+      "highlight",
+      "color",
+      "draw",
+      "ink",
+      "tool"
+    ]
+  },
+  {
+    "Code": "ED65",
+    "Name": "InkingCaret",
+    "Tags": [
+      "text",
+      "cursor",
+      "writing"
+    ]
+  },
+  {
+    "Code": "ED66",
+    "Name": "InkingColorOutline",
+    "Tags": [
+      "circle",
+      "border",
+      "outline",
+      "draw"
+    ]
+  },
+  {
+    "Code": "ED67",
+    "Name": "InkingColorFill",
+    "Tags": [
+      "circle",
+      "ink",
+      "paint",
+      "design"
+    ]
+  },
+  {
+    "Code": "EDA2",
+    "Name": "HardDrive",
+    "Tags": [
+      "storage",
+      "disk",
+      "data",
+      "backup",
+      "memory"
+    ]
+  },
+  {
+    "Code": "EDA3",
+    "Name": "NetworkAdapter",
+    "Tags": [
+      "connection",
+      "Wifi",
+      "Ethernet",
+      "internet",
+      "device"
+    ]
+  },
+  {
+    "Code": "EDA4",
+    "Name": "Touchscreen",
+    "Tags": [
+      "display",
+      "interactive",
+      "tablet"
+    ]
+  },
+  {
+    "Code": "EDA5",
+    "Name": "NetworkPrinter",
+    "Tags": [
+      "print",
+      "wireless",
+      "office",
+      "device"
+    ]
+  },
+  {
+    "Code": "EDA6",
+    "Name": "CloudPrinter",
+    "Tags": [
+      "online",
+      "remote",
+      "document"
+    ]
+  },
+  {
+    "Code": "EDA7",
+    "Name": "KeyboardShortcut",
+    "Tags": [
+      "keys",
+      "command"
+    ]
+  },
+  {
+    "Code": "EDA8",
+    "Name": "BrushSize",
+    "Tags": [
+      "draw",
+      "tool",
+      "paint",
+      "editing"
+    ]
+  },
+  {
+    "Code": "EDA9",
+    "Name": "NarratorForward",
+    "Tags": [
+      "accessibility",
+      "voice",
+      "audio",
+      "screen",
+      "reader",
+      "text",
+      "assistive"
+    ]
+  },
+  {
+    "Code": "EDAA",
+    "Name": "NarratorForwardMirrored",
+    "Tags": [
+      "accessibility",
+      "voice",
+      "audio",
+      "screen",
+      "reader",
+      "text",
+      "assistive"
+    ]
+  },
+  {
+    "Code": "EDAB",
+    "Name": "SyncBadge12",
+    "Tags": [
+      "arrow",
+      "update",
+      "refresh",
+      "sync",
+      "refresh"
+    ]
+  },
+  {
+    "Code": "EDAC",
+    "Name": "RingerBadge12",
+    "Tags": [
+      "bell",
+      "notification",
+      "alert"
+    ]
+  },
+  {
+    "Code": "EDAD",
+    "Name": "AsteriskBadge12",
+    "Tags": [
+      "*",
+      "star",
+      "symbol",
+      "wildcard",
+      "mark",
+      "notation"
+    ]
+  },
+  {
+    "Code": "EDAE",
+    "Name": "ErrorBadge12",
+    "Tags": [
+      "x",
+      "warning",
+      "alert",
+      "problem",
+      "notification"
+    ]
+  },
+  {
+    "Code": "EDAF",
+    "Name": "CircleRingBadge12",
+    "Tags": [
+      "shape",
+      "geometry"
+    ]
+  },
+  {
+    "Code": "EDB0",
+    "Name": "CircleFillBadge12",
+    "Tags": [
+      "shape",
+      "geometry"
+    ]
+  },
+  {
+    "Code": "EDB1",
+    "Name": "ImportantBadge12",
+    "Tags": [
+      "!",
+      "priority",
+      "highlight",
+      "urgent",
+      "attention",
+      "critical"
+    ]
+  },
+  {
+    "Code": "EDB3",
+    "Name": "MailBadge12",
+    "Tags": [
+      "envelope",
+      "email",
+      "delivery",
+      "message",
+      "letter"
+    ]
+  },
+  {
+    "Code": "EDB4",
+    "Name": "PauseBadge12",
+    "Tags": [
+      "control",
+      "playback",
+      "freeze"
+    ]
+  },
+  {
+    "Code": "EDB5",
+    "Name": "PlayBadge12",
+    "Tags": [
+      "control",
+      "playback",
+      "start",
+      "begin"
+    ]
+  },
+  {
+    "Code": "EDC6",
+    "Name": "PenWorkspace",
+    "Tags": [
+      "inking",
+      "drawing",
+      "stylus",
+      "workspace"
+    ]
+  },
+  {
+    "Code": "EDD5",
+    "Name": "CaretLeft8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDD6",
+    "Name": "CaretRight8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDD7",
+    "Name": "CaretUp8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDD8",
+    "Name": "CaretDown8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDD9",
+    "Name": "CaretLeftSolid8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDDA",
+    "Name": "CaretRightSolid8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDDB",
+    "Name": "CaretUpSolid8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDDC",
+    "Name": "CaretDownSolid8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "EDE0",
+    "Name": "Strikethrough",
+    "Tags": []
+  },
+  {
+    "Code": "EDE1",
+    "Name": "Export",
+    "Tags": [
+      "arrow",
+      "share",
+      "save",
+      "transfer",
+      "download",
+      "output"
+    ]
+  },
+  {
+    "Code": "EDE2",
+    "Name": "ExportMirrored",
+    "Tags": [
+      "arrow",
+      "share",
+      "save",
+      "transfer",
+      "download",
+      "output"
+    ]
+  },
+  {
+    "Code": "EDE3",
+    "Name": "ButtonMenu",
+    "Tags": [
+      "navigation",
+      "hamburger",
+      "line",
+      "three",
+      "options"
+    ]
+  },
+  {
+    "Code": "EDE4",
+    "Name": "CloudSearch",
+    "Tags": [
+      "data",
+      "online",
+      "storage",
+      "magnifying glass",
+      "zoom",
+      "inspect",
+      "review"
+    ]
+  },
+  {
+    "Code": "EDE5",
+    "Name": "PinyinIMELogo",
+    "Tags": []
+  },
+  {
+    "Code": "EDFB",
+    "Name": "CalligraphyPen",
+    "Tags": [
+      "writing",
+      "ink",
+      "art",
+      "design",
+      "brush",
+      "stylus"
+    ]
+  },
+  {
+    "Code": "EE35",
+    "Name": "ReplyMirrored",
+    "Tags": [
+      "arrow",
+      "respond",
+      "answer",
+      "return"
+    ]
+  },
+  {
+    "Code": "EE3F",
+    "Name": "LockscreenDesktop",
+    "Tags": [
+      "desktop",
+      "security",
+      "privacy"
+    ]
+  },
+  {
+    "Code": "EE40",
+    "Name": "TaskViewSettings",
+    "Tags": [
+      "multitasking",
+      "management"
+    ]
+  },
+  {
+    "Code": "EE41",
+    "Name": "FullHiraganaPrivateMode",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EE42",
+    "Name": "FullKatakanaPrivateMode",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EE43",
+    "Name": "HalfAlphaPrivateMode",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EE44",
+    "Name": "HalfKatakanaPrivateMode",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EE45",
+    "Name": "FullAlphaPrivateMode",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EE47",
+    "Name": "MiniExpand2Mirrored",
+    "Tags": [
+      "maximize",
+      "view",
+      "minimize",
+      "document"
+    ]
+  },
+  {
+    "Code": "EE49",
+    "Name": "MiniContract2Mirrored",
+    "Tags": [
+      "collapse",
+      "view",
+      "minimize",
+      "document"
+    ]
+  },
+  {
+    "Code": "EE4A",
+    "Name": "Play36",
+    "Tags": [
+      "control",
+      "playback",
+      "start",
+      "begin"
+    ]
+  },
+  {
+    "Code": "EE56",
+    "Name": "PenPalette",
+    "Tags": [
+      "color",
+      "drawing",
+      "art"
+    ]
+  },
+  {
+    "Code": "EE57",
+    "Name": "GuestUser",
+    "Tags": [
+      "person",
+      "login"
+    ]
+  },
+  {
+    "Code": "EE63",
+    "Name": "SettingsBattery",
+    "Tags": [
+      "power",
+      "charge"
+    ]
+  },
+  {
+    "Code": "EE64",
+    "Name": "TaskbarPhone",
+    "Tags": [
+      "mobile",
+      "connect",
+      "device"
+    ]
+  },
+  {
+    "Code": "EE65",
+    "Name": "LockScreenGlance",
+    "Tags": [
+      "display",
+      "quickview",
+      "preview",
+      "eye"
+    ]
+  },
+  {
+    "Code": "EE6F",
+    "Name": "GenericScan",
+    "Tags": [
+      "device",
+      "document",
+      "scanner"
+    ]
+  },
+  {
+    "Code": "EE71",
+    "Name": "ImageExport",
+    "Tags": [
+      "picture",
+      "share",
+      "save"
+    ]
+  },
+  {
+    "Code": "EE77",
+    "Name": "WifiEthernet",
+    "Tags": [
+      "network",
+      "connection",
+      "internet"
+    ]
+  },
+  {
+    "Code": "EE79",
+    "Name": "ActionCenterQuiet",
+    "Tags": [
+      "night",
+      "moon"
+    ]
+  },
+  {
+    "Code": "EE7A",
+    "Name": "ActionCenterQuietNotification",
+    "Tags": [
+      "night",
+      "moon"
+    ]
+  },
+  {
+    "Code": "EE7E",
+    "Name": "FIDOPasskey",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EE92",
+    "Name": "TrackersMirrored",
+    "Tags": [
+      "check",
+      "monitor",
+      "progress",
+      "list"
+    ]
+  },
+  {
+    "Code": "EE93",
+    "Name": "DateTimeMirrored",
+    "Tags": [
+      "clock",
+      "planning"
+    ]
+  },
+  {
+    "Code": "EE94",
+    "Name": "Wheel",
+    "Tags": []
+  },
+  {
+    "Code": "EE95",
+    "Name": "StopSolid",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EEA0",
+    "Name": "RAM",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EEA1",
+    "Name": "CPU",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EEA3",
+    "Name": "VirtualMachineGroup",
+    "Tags": [
+      "cloud",
+      "computing"
+    ]
+  },
+  {
+    "Code": "EECA",
+    "Name": "ButtonView2",
+    "Tags": [
+      "interface",
+      "UI",
+      "toggle"
+    ]
+  },
+  {
+    "Code": "EF15",
+    "Name": "PenWorkspaceMirrored",
+    "Tags": [
+      "inking",
+      "drawing",
+      "stylus",
+      "workspace"
+    ]
+  },
+  {
+    "Code": "EF16",
+    "Name": "PenPaletteMirrored",
+    "Tags": [
+      "color",
+      "drawing",
+      "art"
+    ]
+  },
+  {
+    "Code": "EF17",
+    "Name": "StrokeEraseMirrored",
+    "Tags": [
+      "delete",
+      "drawing",
+      "line",
+      "correction"
+    ]
+  },
+  {
+    "Code": "EF18",
+    "Name": "PointEraseMirrored",
+    "Tags": [
+      "remove",
+      "spot",
+      "dot",
+      "edit"
+    ]
+  },
+  {
+    "Code": "EF19",
+    "Name": "ClearAllInkMirrored",
+    "Tags": [
+      "reset",
+      "erase",
+      "drawing"
+    ]
+  },
+  {
+    "Code": "EF1F",
+    "Name": "BackgroundToggle",
+    "Tags": [
+      "switch",
+      "mode",
+      "settings"
+    ]
+  },
+  {
+    "Code": "EF20",
+    "Name": "Marquee",
+    "Tags": [
+      "capture",
+      "screenshot",
+      "screen",
+      "snapshot",
+      "image"
+    ]
+  },
+  {
+    "Code": "EF2C",
+    "Name": "ChromeCloseContrast",
+    "Tags": [
+      "x",
+      "exit",
+      "cancel",
+      "shut",
+      "dismiss"
+    ]
+  },
+  {
+    "Code": "EF2D",
+    "Name": "ChromeMinimizeContrast",
+    "Tags": [
+      "-",
+      "window",
+      "shrink",
+      "small",
+      "collapse",
+      "resize"
+    ]
+  },
+  {
+    "Code": "EF2E",
+    "Name": "ChromeMaximizeContrast",
+    "Tags": [
+      "window",
+      "expand",
+      "full screen",
+      "enlarge",
+      "width",
+      "height",
+      "resize",
+      "fill",
+      "fit"
+    ]
+  },
+  {
+    "Code": "EF2F",
+    "Name": "ChromeRestoreContrast",
+    "Tags": [
+      "window",
+      "resize",
+      "default",
+      "revert"
+    ]
+  },
+  {
+    "Code": "EF31",
+    "Name": "TrafficLight",
+    "Tags": [
+      "signal",
+      "control",
+      "stop",
+      "road"
+    ]
+  },
+  {
+    "Code": "EF3B",
+    "Name": "Replay",
+    "Tags": [
+      "arrow",
+      "repeat"
+    ]
+  },
+  {
+    "Code": "EF3C",
+    "Name": "Eyedropper",
+    "Tags": [
+      "color",
+      "picker",
+      "sample",
+      "paint",
+      "tool"
+    ]
+  },
+  {
+    "Code": "EF3D",
+    "Name": "LineDisplay",
+    "Tags": [
+      "screen",
+      "output",
+      "visual",
+      "price",
+      "checkout",
+      "transaction",
+      "purchase",
+      "receipt"
+    ]
+  },
+  {
+    "Code": "EF3E",
+    "Name": "PINPad",
+    "Tags": [
+      "payment",
+      "transaction",
+      "security",
+      "card"
+    ]
+  },
+  {
+    "Code": "EF3F",
+    "Name": "SignatureCapture",
+    "Tags": [
+      "authentication",
+      "verification",
+      "agreement",
+      "document"
+    ]
+  },
+  {
+    "Code": "EF40",
+    "Name": "ChipCardCreditCardReader",
+    "Tags": [
+      "payment",
+      "transaction",
+      "secure",
+      "banking"
+    ]
+  },
+  {
+    "Code": "EF42",
+    "Name": "MarketDown",
+    "Tags": [
+      "arrow",
+      "decrease",
+      "decline",
+      "fall",
+      "stock"
+    ]
+  },
+  {
+    "Code": "EF58",
+    "Name": "PlayerSettings",
+    "Tags": [
+      "person",
+      "user"
+    ]
+  },
+  {
+    "Code": "EF60",
+    "Name": "TextEdit",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EF6B",
+    "Name": "LandscapeOrientation",
+    "Tags": [
+      "screen",
+      "display",
+      "view",
+      "horizontal",
+      "wide"
+    ]
+  },
+  {
+    "Code": "EF90",
+    "Name": "Flow",
+    "Tags": [
+      "movement",
+      "stream",
+      "direction",
+      "process",
+      "continuity",
+      "sequence",
+      "fluid"
+    ]
+  },
+  {
+    "Code": "EFA5",
+    "Name": "Touchpad",
+    "Tags": [
+      "input",
+      "gesture",
+      "control",
+      "navigation",
+      "interface",
+      "trackpad",
+      "device"
+    ]
+  },
+  {
+    "Code": "EFA9",
+    "Name": "Speech",
+    "Tags": [
+      "person",
+      "user",
+      "audio",
+      "talking"
+    ]
+  },
+  {
+    "Code": "EFDA",
+    "Name": "AppIconDefaultAdd",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "EFFF",
+    "Name": "CRMScheduleReports",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F000",
+    "Name": "KnowledgeArticle",
+    "Tags": [
+      "page",
+      "document"
+    ]
+  },
+  {
+    "Code": "F003",
+    "Name": "Relationship",
+    "Tags": [
+      "data",
+      "link",
+      "connection",
+      "association",
+      "schema",
+      "model",
+      "structure",
+      "dependency"
+    ]
+  },
+  {
+    "Code": "F012",
+    "Name": "ZipFolder",
+    "Tags": [
+      "compress",
+      "archive",
+      "zip",
+      "package",
+      "file",
+      "storage",
+      "extract"
+    ]
+  },
+  {
+    "Code": "F080",
+    "Name": "DefaultAPN",
+    "Tags": [
+      "network",
+      "settings",
+      "connection",
+      "mobile",
+      "provider",
+      "internet",
+      "configuration"
+    ]
+  },
+  {
+    "Code": "F081",
+    "Name": "UserAPN",
+    "Tags": [
+      "person",
+      "network",
+      "settings",
+      "connection",
+      "mobile",
+      "provider",
+      "internet",
+      "configuration"
+    ]
+  },
+  {
+    "Code": "F085",
+    "Name": "DoublePinyin",
+    "Tags": [
+      "alphabet",
+      "translation"
+    ]
+  },
+  {
+    "Code": "F08C",
+    "Name": "BlueLight",
+    "Tags": [
+      "brightness",
+      "sun",
+      "dark"
+    ]
+  },
+  {
+    "Code": "F08D",
+    "Name": "CaretSolidLeft",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "F08E",
+    "Name": "CaretSolidDown",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "F08F",
+    "Name": "CaretSolidRight",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "F090",
+    "Name": "CaretSolidUp",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "F093",
+    "Name": "ButtonA",
+    "Tags": []
+  },
+  {
+    "Code": "F094",
+    "Name": "ButtonB",
+    "Tags": []
+  },
+  {
+    "Code": "F095",
+    "Name": "ButtonY",
+    "Tags": []
+  },
+  {
+    "Code": "F096",
+    "Name": "ButtonX",
+    "Tags": []
+  },
+  {
+    "Code": "F0AD",
+    "Name": "ArrowUp8",
+    "Tags": []
+  },
+  {
+    "Code": "F0AE",
+    "Name": "ArrowDown8",
+    "Tags": []
+  },
+  {
+    "Code": "F0AF",
+    "Name": "ArrowRight8",
+    "Tags": []
+  },
+  {
+    "Code": "F0B0",
+    "Name": "ArrowLeft8",
+    "Tags": []
+  },
+  {
+    "Code": "F0B2",
+    "Name": "QuarentinedItems",
+    "Tags": [
+      "security",
+      "protection",
+      "virus",
+      "malware",
+      "threat",
+      "files",
+      "safety"
+    ]
+  },
+  {
+    "Code": "F0B3",
+    "Name": "QuarentinedItemsMirrored",
+    "Tags": [
+      "security",
+      "protection",
+      "virus",
+      "malware",
+      "threat",
+      "files",
+      "safety"
+    ]
+  },
+  {
+    "Code": "F0B4",
+    "Name": "Protractor",
+    "Tags": [
+      "measurement",
+      "angle",
+      "geometry",
+      "tool",
+      "math"
+    ]
+  },
+  {
+    "Code": "F0B5",
+    "Name": "ChecklistMirrored",
+    "Tags": [
+      "tasks",
+      "items",
+      "organize",
+      "progress",
+      "completion"
+    ]
+  },
+  {
+    "Code": "F0B6",
+    "Name": "StatusCircle7",
+    "Tags": [
+      "indicator",
+      "circle",
+      "check",
+      "signal"
+    ]
+  },
+  {
+    "Code": "F0B7",
+    "Name": "StatusCheckmark7",
+    "Tags": [
+      "verification",
+      "confirmation",
+      "success",
+      "approval",
+      "completed",
+      "done"
+    ]
+  },
+  {
+    "Code": "F0B8",
+    "Name": "StatusErrorCircle7",
+    "Tags": [
+      "x",
+      "problem",
+      "failure",
+      "alert"
+    ]
+  },
+  {
+    "Code": "F0B9",
+    "Name": "Connected",
+    "Tags": [
+      "network",
+      "connection",
+      "online",
+      "linked",
+      "paired",
+      "access",
+      "communication",
+      "status"
+    ]
+  },
+  {
+    "Code": "F0C6",
+    "Name": "PencilFill",
+    "Tags": [
+      "write",
+      "draw",
+      "sketch",
+      "tool",
+      "creative"
+    ]
+  },
+  {
+    "Code": "F0C7",
+    "Name": "CalligraphyFill",
+    "Tags": [
+      "writing",
+      "ink",
+      "pen",
+      "art",
+      "design",
+      "brush",
+      "stylus"
+    ]
+  },
+  {
+    "Code": "F0CA",
+    "Name": "QuarterStarLeft",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0CB",
+    "Name": "QuarterStarRight",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0CC",
+    "Name": "ThreeQuarterStarLeft",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0CD",
+    "Name": "ThreeQuarterStarRight",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0CE",
+    "Name": "QuietHoursBadge12",
+    "Tags": [
+      "moon",
+      "night"
+    ]
+  },
+  {
+    "Code": "F0D2",
+    "Name": "BackMirrored",
+    "Tags": [
+      "arrow",
+      "previous",
+      "return",
+      "left",
+      "rewind"
+    ]
+  },
+  {
+    "Code": "F0D3",
+    "Name": "ForwardMirrored",
+    "Tags": [
+      "arrow",
+      "next",
+      "send",
+      "right",
+      "proceed"
+    ]
+  },
+  {
+    "Code": "F0D5",
+    "Name": "ChromeBackContrast",
+    "Tags": [
+      "arrow",
+      "back",
+      "navigate",
+      "browser"
+    ]
+  },
+  {
+    "Code": "F0D6",
+    "Name": "ChromeBackContrastMirrored",
+    "Tags": [
+      "arrow",
+      "back",
+      "navigate",
+      "browser"
+    ]
+  },
+  {
+    "Code": "F0D7",
+    "Name": "ChromeBackToWindowContrast",
+    "Tags": [
+      "arrow",
+      "back",
+      "navigate",
+      "browser"
+    ]
+  },
+  {
+    "Code": "F0D8",
+    "Name": "ChromeFullScreenContrast",
+    "Tags": [
+      "arrow",
+      "expand",
+      "maximize",
+      "window",
+      "view"
+    ]
+  },
+  {
+    "Code": "F0E2",
+    "Name": "GridView",
+    "Tags": [
+      "layout",
+      "design",
+      "display",
+      "structure",
+      "applications",
+      "menu",
+      "apps",
+      "programs"
+    ]
+  },
+  {
+    "Code": "F0E3",
+    "Name": "ClipboardList",
+    "Tags": [
+      "copy",
+      "paste",
+      "data",
+      "items",
+      "records"
+    ]
+  },
+  {
+    "Code": "F0E4",
+    "Name": "ClipboardListMirrored",
+    "Tags": [
+      "copy",
+      "paste",
+      "data",
+      "items",
+      "records"
+    ]
+  },
+  {
+    "Code": "F0E5",
+    "Name": "OutlineQuarterStarLeft",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0E6",
+    "Name": "OutlineQuarterStarRight",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0E7",
+    "Name": "OutlineHalfStarLeft",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0E8",
+    "Name": "OutlineHalfStarRight",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0E9",
+    "Name": "OutlineThreeQuarterStarLeft",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0EA",
+    "Name": "OutlineThreeQuarterStarRight",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0EB",
+    "Name": "SpatialVolume0",
+    "Tags": [
+      "volume",
+      "sound",
+      "audio",
+      "mute"
+    ]
+  },
+  {
+    "Code": "F0EC",
+    "Name": "SpatialVolume1",
+    "Tags": [
+      "volume",
+      "sound",
+      "audio",
+      "low"
+    ]
+  },
+  {
+    "Code": "F0ED",
+    "Name": "SpatialVolume2",
+    "Tags": [
+      "volume",
+      "sound",
+      "audio",
+      "medium"
+    ]
+  },
+  {
+    "Code": "F0EE",
+    "Name": "SpatialVolume3",
+    "Tags": [
+      "volume",
+      "sound",
+      "audio",
+      "hight"
+    ]
+  },
+  {
+    "Code": "F0EF",
+    "Name": "ApplicationGuard",
+    "Tags": [
+      "defender",
+      "shield",
+      "security",
+      "protection",
+      "safety"
+    ]
+  },
+  {
+    "Code": "F0F7",
+    "Name": "OutlineStarLeftHalf",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0F8",
+    "Name": "OutlineStarRightHalf",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0F9",
+    "Name": "ChromeAnnotateContrast",
+    "Tags": [
+      "rating",
+      "score",
+      "evaluation",
+      "feedback",
+      "review"
+    ]
+  },
+  {
+    "Code": "F0FB",
+    "Name": "DefenderBadge12",
+    "Tags": [
+      "shield",
+      "security",
+      "protection",
+      "safety"
+    ]
+  },
+  {
+    "Code": "F103",
+    "Name": "DetachablePC",
+    "Tags": [
+      "device",
+      "laptop",
+      "tablet",
+      "removable",
+      "portable",
+      "screen"
+    ]
+  },
+  {
+    "Code": "F108",
+    "Name": "LeftStick",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F109",
+    "Name": "RightStick",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F10A",
+    "Name": "TriggerLeft",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F10B",
+    "Name": "TriggerRight",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F10C",
+    "Name": "BumperLeft",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F10D",
+    "Name": "BumperRight",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F10E",
+    "Name": "Dpad",
+    "Tags": [
+      "controller",
+      "gamepad",
+      "joystick",
+      "input",
+      "navigation",
+      "buttons",
+      "gaming"
+    ]
+  },
+  {
+    "Code": "F110",
+    "Name": "EnglishPunctuation",
+    "Tags": [
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "F111",
+    "Name": "ChinesePunctuation",
+    "Tags": [
+      "symbol",
+      "character",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "F119",
+    "Name": "HMD",
+    "Tags": [
+      "headset",
+      "VR",
+      "virtual",
+      "display",
+      "device"
+    ]
+  },
+  {
+    "Code": "F11B",
+    "Name": "CtrlSpatialRight",
+    "Tags": []
+  },
+  {
+    "Code": "F126",
+    "Name": "PaginationDotOutline10",
+    "Tags": [
+      "circle"
+    ]
+  },
+  {
+    "Code": "F127",
+    "Name": "PaginationDotSolid10",
+    "Tags": [
+      "circle"
+    ]
+  },
+  {
+    "Code": "F128",
+    "Name": "StrokeErase2",
+    "Tags": [
+      "delete",
+      "drawing",
+      "line",
+      "correction"
+    ]
+  },
+  {
+    "Code": "F129",
+    "Name": "SmallErase",
+    "Tags": [
+      "delete",
+      "drawing",
+      "correction"
+    ]
+  },
+  {
+    "Code": "F12A",
+    "Name": "LargeErase",
+    "Tags": [
+      "delete",
+      "drawing",
+      "correction"
+    ]
+  },
+  {
+    "Code": "F12B",
+    "Name": "FolderHorizontal",
+    "Tags": [
+      "collection",
+      "directory",
+      "file",
+      "storage"
+    ]
+  },
+  {
+    "Code": "F12E",
+    "Name": "MicrophoneListening",
+    "Tags": [
+      "audio",
+      "active",
+      "sound",
+      "enabled",
+      "recording"
+    ]
+  },
+  {
+    "Code": "F12F",
+    "Name": "StatusExclamationCircle7",
+    "Tags": [
+      "!",
+      "indicator",
+      "progress",
+      "caution",
+      "attention"
+    ]
+  },
+  {
+    "Code": "F131",
+    "Name": "Video360",
+    "Tags": [
+      "immersive",
+      "VR",
+      "panorama"
+    ]
+  },
+  {
+    "Code": "F133",
+    "Name": "GiftboxOpen",
+    "Tags": [
+      "present",
+      "unpack"
+    ]
+  },
+  {
+    "Code": "F136",
+    "Name": "StatusCircleOuter",
+    "Tags": []
+  },
+  {
+    "Code": "F137",
+    "Name": "StatusCircleInner",
+    "Tags": []
+  },
+  {
+    "Code": "F138",
+    "Name": "StatusCircleRing",
+    "Tags": []
+  },
+  {
+    "Code": "F139",
+    "Name": "StatusTriangleOuter",
+    "Tags": []
+  },
+  {
+    "Code": "F13A",
+    "Name": "StatusTriangleInner",
+    "Tags": []
+  },
+  {
+    "Code": "F13B",
+    "Name": "StatusTriangleExclamation",
+    "Tags": [
+      "!",
+      "indicator",
+      "progress",
+      "caution",
+      "attention"
+    ]
+  },
+  {
+    "Code": "F13C",
+    "Name": "StatusCircleExclamation",
+    "Tags": [
+      "!",
+      "indicator",
+      "progress",
+      "caution",
+      "attention"
+    ]
+  },
+  {
+    "Code": "F13D",
+    "Name": "StatusCircleErrorX",
+    "Tags": [
+      "x",
+      "problem",
+      "failure",
+      "alert"
+    ]
+  },
+  {
+    "Code": "F13E",
+    "Name": "StatusCircleCheckmark",
+    "Tags": [
+      "verification",
+      "confirmation",
+      "success",
+      "approval",
+      "completed",
+      "done"
+    ]
+  },
+  {
+    "Code": "F13F",
+    "Name": "StatusCircleInfo",
+    "Tags": [
+      "information",
+      "details",
+      "content"
+    ]
+  },
+  {
+    "Code": "F140",
+    "Name": "StatusCircleBlock",
+    "Tags": [
+      "restrict",
+      "stop",
+      "cancel",
+      "end"
+    ]
+  },
+  {
+    "Code": "F141",
+    "Name": "StatusCircleBlock2",
+    "Tags": [
+      "restrict"
+    ]
+  },
+  {
+    "Code": "F142",
+    "Name": "StatusCircleQuestionMark",
+    "Tags": [
+      "?",
+      "help",
+      "support",
+      "guide",
+      "assistance",
+      "info"
+    ]
+  },
+  {
+    "Code": "F143",
+    "Name": "StatusCircleSync",
+    "Tags": [
+      "arrow"
+    ]
+  },
+  {
+    "Code": "F146",
+    "Name": "Dial1",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F147",
+    "Name": "Dial2",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F148",
+    "Name": "Dial3",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F149",
+    "Name": "Dial4",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F14A",
+    "Name": "Dial5",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F14B",
+    "Name": "Dial6",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F14C",
+    "Name": "Dial7",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F14D",
+    "Name": "Dial8",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F14E",
+    "Name": "Dial9",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F14F",
+    "Name": "Dial10",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F150",
+    "Name": "Dial11",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F151",
+    "Name": "Dial12",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F152",
+    "Name": "Dial13",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F153",
+    "Name": "Dial14",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F154",
+    "Name": "Dial15",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F155",
+    "Name": "Dial16",
+    "Tags": [
+      "number"
+    ]
+  },
+  {
+    "Code": "F156",
+    "Name": "DialShape1",
+    "Tags": [
+      "stack",
+      "overlap",
+      "levels",
+      "structure"
+    ]
+  },
+  {
+    "Code": "F157",
+    "Name": "DialShape2",
+    "Tags": [
+      "pyramid",
+      "3D",
+      "geometry",
+      "structure"
+    ]
+  },
+  {
+    "Code": "F158",
+    "Name": "DialShape3",
+    "Tags": [
+      "cube",
+      "3D",
+      "geometry",
+      "block"
+    ]
+  },
+  {
+    "Code": "F159",
+    "Name": "DialShape4",
+    "Tags": [
+      "octahedron",
+      "3D",
+      "geometry",
+      "shape",
+      "polygon"
+    ]
+  },
+  {
+    "Code": "F15F",
+    "Name": "ClosedCaptionsInternational",
+    "Tags": [
+      "text",
+      "dialogue",
+      "speech",
+      "language",
+      "cc",
+      "subtitles"
+    ]
+  },
+  {
+    "Code": "F161",
+    "Name": "TollSolid",
+    "Tags": [
+      "payment",
+      "road",
+      "fee",
+      "bridge"
+    ]
+  },
+  {
+    "Code": "F163",
+    "Name": "TrafficCongestionSolid",
+    "Tags": [
+      "car",
+      "jam",
+      "road",
+      "delay"
+    ]
+  },
+  {
+    "Code": "F164",
+    "Name": "ExploreContentSingle",
+    "Tags": [
+      "+",
+      "discover",
+      "browse",
+      "navigate"
+    ]
+  },
+  {
+    "Code": "F165",
+    "Name": "CollapseContent",
+    "Tags": [
+      "-",
+      "shrink",
+      "small",
+      "hide",
+      "resize"
+    ]
+  },
+  {
+    "Code": "F166",
+    "Name": "CollapseContentSingle",
+    "Tags": [
+      "-",
+      "shrink",
+      "small",
+      "hide",
+      "resize"
+    ]
+  },
+  {
+    "Code": "F167",
+    "Name": "InfoSolid",
+    "Tags": [
+      "information",
+      "details",
+      "content"
+    ]
+  },
+  {
+    "Code": "F168",
+    "Name": "GroupList",
+    "Tags": [
+      "items",
+      "collection",
+      "organization"
+    ]
+  },
+  {
+    "Code": "F169",
+    "Name": "CaretBottomRightSolidCenter8",
+    "Tags": [
+      "triangle"
+    ]
+  },
+  {
+    "Code": "F16A",
+    "Name": "ProgressRingDots",
+    "Tags": [
+      "loading",
+      "indicator",
+      "status",
+      "waiting"
+    ]
+  },
+  {
+    "Code": "F16B",
+    "Name": "Checkbox14",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "F16C",
+    "Name": "CheckboxComposite14",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "F16D",
+    "Name": "CheckboxIndeterminateCombo14",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "F16E",
+    "Name": "CheckboxIndeterminateCombo",
+    "Tags": [
+      "selection",
+      "check",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "F175",
+    "Name": "StatusPause7",
+    "Tags": [
+      "halted",
+      "interrupted",
+      "delay",
+      "standby"
+    ]
+  },
+  {
+    "Code": "F17F",
+    "Name": "CharacterAppearance",
+    "Tags": [
+      "font",
+      "style",
+      "text",
+      "lettering",
+      "typography"
+    ]
+  },
+  {
+    "Code": "F180",
+    "Name": "Lexicon",
+    "Tags": [
+      "person",
+      "user",
+      "book"
+    ]
+  },
+  {
+    "Code": "F182",
+    "Name": "ScreenTime",
+    "Tags": [
+      "clock",
+      "monitor",
+      "usage",
+      "device"
+    ]
+  },
+  {
+    "Code": "F191",
+    "Name": "HeadlessDevice",
+    "Tags": [
+      "server",
+      "device",
+      "remote",
+      "management",
+      "network"
+    ]
+  },
+  {
+    "Code": "F193",
+    "Name": "NetworkSharing",
+    "Tags": [
+      "printer",
+      "folder",
+      "connection"
+    ]
+  },
+  {
+    "Code": "F19D",
+    "Name": "EyeGaze",
+    "Tags": [
+      "focus",
+      "tracking",
+      "vision"
+    ]
+  },
+  {
+    "Code": "F19E",
+    "Name": "ToggleLeft",
+    "Tags": [
+      "switch",
+      "off",
+      "inactive"
+    ]
+  },
+  {
+    "Code": "F19F",
+    "Name": "ToggleRight",
+    "Tags": [
+      "switch",
+      "off",
+      "inactive"
+    ]
+  },
+  {
+    "Code": "F1AD",
+    "Name": "WindowsInsider",
+    "Tags": [
+      "program",
+      "beta",
+      "preview"
+    ]
+  },
+  {
+    "Code": "F1CB",
+    "Name": "ChromeSwitch",
+    "Tags": [
+      "arrow",
+      "change",
+      "swap",
+      "toggle",
+      "shift",
+      "alternate"
+    ]
+  },
+  {
+    "Code": "F1CC",
+    "Name": "ChromeSwitchContast",
+    "Tags": [
+      "arrow",
+      "change",
+      "swap",
+      "toggle",
+      "shift",
+      "alternate"
+    ]
+  },
+  {
+    "Code": "F1D8",
+    "Name": "StatusCheckmark",
+    "Tags": [
+      "verification",
+      "confirmation",
+      "success",
+      "approval",
+      "completed",
+      "done"
+    ]
+  },
+  {
+    "Code": "F1D9",
+    "Name": "StatusCheckmarkLeft",
+    "Tags": [
+      "verification",
+      "confirmation",
+      "success",
+      "approval",
+      "completed",
+      "done"
+    ]
+  },
+  {
+    "Code": "F20C",
+    "Name": "KeyboardLeftAligned",
+    "Tags": [
+      "position",
+      "layout",
+      "left-align",
+      "design"
+    ]
+  },
+  {
+    "Code": "F20D",
+    "Name": "KeyboardRightAligned",
+    "Tags": [
+      "position",
+      "layout",
+      "right-align",
+      "design"
+    ]
+  },
+  {
+    "Code": "F210",
+    "Name": "KeyboardSettings",
+    "Tags": [
+      "preferences",
+      "adjust",
+      "controls",
+      "configuration",
+      "customization"
+    ]
+  },
+  {
+    "Code": "F211",
+    "Name": "NetworkPhysical",
+    "Tags": [
+      "connection",
+      "hardware",
+      "cable",
+      "data",
+      "wireless"
+    ]
+  },
+  {
+    "Code": "F22C",
+    "Name": "IOT",
+    "Tags": [
+      "internet",
+      "devices",
+      "network",
+      "automation",
+      "sensors",
+      "connectivity",
+      "smart",
+      "chemical",
+      "formaldehyde"
+    ]
+  },
+  {
+    "Code": "F22E",
+    "Name": "UnknownMirrored",
+    "Tags": [
+      "?",
+      "question",
+      "uncertain"
+    ]
+  },
+  {
+    "Code": "F246",
+    "Name": "ViewDashboard",
+    "Tags": [
+      "interface",
+      "data",
+      "visualization",
+      "monitoring"
+    ]
+  },
+  {
+    "Code": "F259",
+    "Name": "ExploitProtectionSettings",
+    "Tags": [
+      "security",
+      "configuration",
+      "defense"
+    ]
+  },
+  {
+    "Code": "F260",
+    "Name": "KeyboardNarrow",
+    "Tags": [
+      "compact",
+      "size",
+      "layout",
+      "space-saving",
+      "design"
+    ]
+  },
+  {
+    "Code": "F261",
+    "Name": "Keyboard12Key",
+    "Tags": [
+      "numeric",
+      "layout",
+      "compact",
+      "keypad",
+      "numbers"
+    ]
+  },
+  {
+    "Code": "F26B",
+    "Name": "KeyboardDock",
+    "Tags": [
+      "attachment",
+      "mount",
+      "position",
+      "connection",
+      "setup"
+    ]
+  },
+  {
+    "Code": "F26C",
+    "Name": "KeyboardUndock",
+    "Tags": [
+      "detachment",
+      "release",
+      "disconnection",
+      "mobile"
+    ]
+  },
+  {
+    "Code": "F26D",
+    "Name": "KeyboardLeftDock",
+    "Tags": [
+      "attachment",
+      "position",
+      "alignment",
+      "setup"
+    ]
+  },
+  {
+    "Code": "F26E",
+    "Name": "KeyboardRightDock",
+    "Tags": [
+      "attachment",
+      "position",
+      "alignment",
+      "setup"
+    ]
+  },
+  {
+    "Code": "F270",
+    "Name": "Ear",
+    "Tags": [
+      "hearing",
+      "sound",
+      "audio",
+      "earphone",
+      "listening"
+    ]
+  },
+  {
+    "Code": "F271",
+    "Name": "PointerHand",
+    "Tags": [
+      "cursor",
+      "click",
+      "select",
+      "interaction",
+      "gesture",
+      "touch"
+    ]
+  },
+  {
+    "Code": "F272",
+    "Name": "Bullseye",
+    "Tags": [
+      "goal",
+      "target",
+      "objective",
+      "achievement",
+      "focus",
+      "precision",
+      "aim",
+      "success"
+    ]
+  },
+  {
+    "Code": "F28B",
+    "Name": "DocumentApproval",
+    "Tags": [
+      "page",
+      "file",
+      "sheet",
+      "paper",
+      "text",
+      "verification",
+      "confirmation",
+      "success",
+      "approval",
+      "completed",
+      "done"
+    ]
+  },
+  {
+    "Code": "F2B7",
+    "Name": "LocaleLanguage",
+    "Tags": [
+      "region",
+      "localization",
+      "translation",
+      "culture",
+      "setting",
+      "preferences"
+    ]
+  },
+  {
+    "Code": "F112",
+    "Name": "ReadOutLoud",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F117",
+    "Name": "ProjectToDevice",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F120",
+    "Name": "TaskManagerApp",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F196",
+    "Name": "Beaker",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F1B1",
+    "Name": "PowerButtonUpdate2",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F1E8",
+    "Name": "LeafTwo",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F232",
+    "Name": "GridViewSmall",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F27C",
+    "Name": "Earbudsingle",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F27F",
+    "Name": "HearingAid",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F285",
+    "Name": "MobSnooze",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F2A3",
+    "Name": "MobNotificationBell",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F2A5",
+    "Name": "MobNotificationBellFilled",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F2A8",
+    "Name": "MobSnoozeFilled",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F2C7",
+    "Name": "BulletedList2",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F2C8",
+    "Name": "BulletedList2Mirrored",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F2D9",
+    "Name": "CirclePause",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F32A",
+    "Name": "PassiveAuthentication",
+    "Tags": [
+      "security",
+      "verification",
+      "identity",
+      "login",
+      "access",
+      "privacy",
+      "checkmark"
+    ]
+  },
+  {
+    "Code": "F354",
+    "Name": "ColorSolid",
+    "Tags": [
+      "palette",
+      "theme"
+    ]
+  },
+  {
+    "Code": "F384",
+    "Name": "NetworkOffline",
+    "Tags": [
+      "connection",
+      "status",
+      "signal"
+    ]
+  },
+  {
+    "Code": "F385",
+    "Name": "NetworkConnected",
+    "Tags": [
+      "connection",
+      "status",
+      "online",
+      "signal"
+    ]
+  },
+  {
+    "Code": "F386",
+    "Name": "NetworkConnectedCheckmark",
+    "Tags": [
+      "connection",
+      "status",
+      "online",
+      "signal"
+    ]
+  },
+  {
+    "Code": "F3B1",
+    "Name": "SignOut",
+    "Tags": [
+      "logout",
+      "exit",
+      "disconnect",
+      "leave",
+      "account",
+      "session",
+      "user"
+    ]
+  },
+  {
+    "Code": "F3CC",
+    "Name": "StatusInfo",
+    "Tags": [
+      "information",
+      "details",
+      "content"
+    ]
+  },
+  {
+    "Code": "F3CD",
+    "Name": "StatusInfoLeft",
+    "Tags": [
+      "information",
+      "details",
+      "content"
+    ]
+  },
+  {
+    "Code": "F3E2",
+    "Name": "NearbySharing",
+    "Tags": [
+      "transfer",
+      "devices",
+      "connect",
+      "send",
+      "bluetooth"
+    ]
+  },
+  {
+    "Code": "F3E7",
+    "Name": "CtrlSpatialLeft",
+    "Tags": []
+  },
+  {
+    "Code": "F404",
+    "Name": "InteractiveDashboard",
+    "Tags": [
+      "interface",
+      "data",
+      "visualization",
+      "monitoring"
+    ]
+  },
+  {
+    "Code": "F405",
+    "Name": "DeclineCall",
+    "Tags": [
+      "phone",
+      "reject",
+      "phone",
+      "communication",
+      "hang up",
+      "contact"
+    ]
+  },
+  {
+    "Code": "F406",
+    "Name": "ClippingTool",
+    "Tags": [
+      "cut",
+      "scissors",
+      "crop",
+      "capture",
+      "screenshot",
+      "screen",
+      "snapshot",
+      "image"
+    ]
+  },
+  {
+    "Code": "F407",
+    "Name": "RectangularClipping",
+    "Tags": [
+      "capture",
+      "screenshot",
+      "screen",
+      "snapshot",
+      "image"
+    ]
+  },
+  {
+    "Code": "F408",
+    "Name": "FreeFormClipping",
+    "Tags": [
+      "capture",
+      "screenshot",
+      "screen",
+      "snapshot",
+      "image"
+    ]
+  },
+  {
+    "Code": "F413",
+    "Name": "CopyTo",
+    "Tags": [
+      "share",
+      "paste",
+      "clipboard"
+    ]
+  },
+  {
+    "Code": "F427",
+    "Name": "IDBadge",
+    "Tags": [
+      "person",
+      "user"
+    ]
+  },
+  {
+    "Code": "F432",
+    "Name": "BatterySaver",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F439",
+    "Name": "DynamicLock",
+    "Tags": [
+      "private",
+      "security",
+      "access",
+      "protected",
+      "safety",
+      "permission",
+      "access",
+      "protection"
+    ]
+  },
+  {
+    "Code": "F45E",
+    "Name": "PenTips",
+    "Tags": [
+      "stylus",
+      "writing",
+      "touch",
+      "input",
+      "tool"
+    ]
+  },
+  {
+    "Code": "F45F",
+    "Name": "PenTipsMirrored",
+    "Tags": [
+      "stylus",
+      "writing",
+      "touch",
+      "input",
+      "tool"
+    ]
+  },
+  {
+    "Code": "F460",
+    "Name": "HWPJoin",
+    "Tags": [
+      "combine",
+      "merge",
+      "stroke"
+    ]
+  },
+  {
+    "Code": "F461",
+    "Name": "HWPInsert",
+    "Tags": [
+      "insert",
+      "add",
+      "place",
+      "input"
+    ]
+  },
+  {
+    "Code": "F462",
+    "Name": "HWPStrikeThrough",
+    "Tags": [
+      "delete",
+      "edit",
+      "mark"
+    ]
+  },
+  {
+    "Code": "F463",
+    "Name": "HWPScratchOut",
+    "Tags": [
+      "erase",
+      "remove",
+      "delete",
+      "correction"
+    ]
+  },
+  {
+    "Code": "F464",
+    "Name": "HWPSplit",
+    "Tags": [
+      "divide",
+      "separate",
+      "line"
+    ]
+  },
+  {
+    "Code": "F465",
+    "Name": "HWPNewLine",
+    "Tags": [
+      "enter",
+      "continue",
+      "paragraph",
+      "space"
+    ]
+  },
+  {
+    "Code": "F466",
+    "Name": "HWPOverwrite",
+    "Tags": [
+      "replace",
+      "modify",
+      "edit",
+      "correction"
+    ]
+  },
+  {
+    "Code": "F473",
+    "Name": "MobWifiWarning1",
+    "Tags": [
+      "!",
+      "connection",
+      "network",
+      "share",
+      "network"
+    ]
+  },
+  {
+    "Code": "F474",
+    "Name": "MobWifiWarning2",
+    "Tags": [
+      "!",
+      "connection",
+      "network",
+      "share",
+      "network"
+    ]
+  },
+  {
+    "Code": "F475",
+    "Name": "MobWifiWarning3",
+    "Tags": [
+      "!",
+      "connection",
+      "network",
+      "share",
+      "network"
+    ]
+  },
+  {
+    "Code": "F476",
+    "Name": "MobWifiWarning4",
+    "Tags": [
+      "!",
+      "connection",
+      "network",
+      "share",
+      "network",
+      "alert",
+      "exclamation",
+      "triangle",
+      "issue"
+    ]
+  },
+  {
+    "Code": "F47F",
+    "Name": "MicLocationCombo",
+    "Tags": [
+      "microphone",
+      "audio"
+    ]
+  },
+  {
+    "Code": "F49A",
+    "Name": "Globe2",
+    "Tags": [
+      "world",
+      "earth",
+      "international",
+      "global"
+    ]
+  },
+  {
+    "Code": "F4A5",
+    "Name": "SpecialEffectSize",
+    "Tags": [
+      "stars",
+      "shine",
+      "twinkle",
+      "glitter",
+      "sparkle",
+      "glow",
+      "magic"
+    ]
+  },
+  {
+    "Code": "F4A9",
+    "Name": "GIF",
+    "Tags": [
+      "animation",
+      "image",
+      "loop",
+      "graphic",
+      "motion",
+      "picture",
+      "media"
+    ]
+  },
+  {
+    "Code": "F4AA",
+    "Name": "Sticker2",
+    "Tags": [
+      "emoji",
+      "expression",
+      "decoration",
+      "image"
+    ]
+  },
+  {
+    "Code": "F4BD",
+    "Name": "Snooze",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F4BE",
+    "Name": "SurfaceHubSelected",
+    "Tags": [
+      "checked",
+      "device",
+      "physical",
+      "product",
+      "screen",
+      "touch screen",
+      "presentation"
+    ]
+  },
+  {
+    "Code": "F4BF",
+    "Name": "HoloLensSelected",
+    "Tags": [
+      "augmented",
+      "reality",
+      "mixed",
+      "virtual",
+      "headset",
+      "checked"
+    ]
+  },
+  {
+    "Code": "F4C0",
+    "Name": "Earbud",
+    "Tags": [
+      "sound",
+      "audio",
+      "music",
+      "volume"
+    ]
+  },
+  {
+    "Code": "F4C3",
+    "Name": "MixVolumes",
+    "Tags": [
+      "sound",
+      "audio",
+      "music",
+      "Equalizer"
+    ]
+  },
+  {
+    "Code": "F540",
+    "Name": "Safe",
+    "Tags": [
+      "security",
+      "protection",
+      "lock",
+      "fireproof",
+      "valuable"
+    ]
+  },
+  {
+    "Code": "F552",
+    "Name": "LaptopSecure",
+    "Tags": [
+      "protection",
+      "shield",
+      "security",
+      "device",
+      "privacy"
+    ]
+  },
+  {
+    "Code": "F56D",
+    "Name": "PrintDefault",
+    "Tags": [
+      "checked",
+      "printer",
+      "document",
+      "settings",
+      "paper",
+      "output",
+      "device"
+    ]
+  },
+  {
+    "Code": "F56E",
+    "Name": "PageMirrored",
+    "Tags": [
+      "document",
+      "file",
+      "sheet",
+      "paper",
+      "text"
+    ]
+  },
+  {
+    "Code": "F56F",
+    "Name": "LandscapeOrientationMirrored",
+    "Tags": [
+      "screen",
+      "display",
+      "view",
+      "horizontal",
+      "wide"
+    ]
+  },
+  {
+    "Code": "F570",
+    "Name": "ColorOff",
+    "Tags": [
+      "palette",
+      "theme"
+    ]
+  },
+  {
+    "Code": "F571",
+    "Name": "PrintAllPages",
+    "Tags": [
+      "printer",
+      "document",
+      "settings",
+      "paper",
+      "output",
+      "device"
+    ]
+  },
+  {
+    "Code": "F572",
+    "Name": "PrintCustomRange",
+    "Tags": [
+      "printer",
+      "document",
+      "settings",
+      "paper",
+      "output",
+      "device"
+    ]
+  },
+  {
+    "Code": "F573",
+    "Name": "PageMarginPortraitNarrow",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F574",
+    "Name": "PageMarginPortraitNormal",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F575",
+    "Name": "PageMarginPortraitModerate",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F576",
+    "Name": "PageMarginPortraitWide",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F577",
+    "Name": "PageMarginLandscapeNarrow",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F578",
+    "Name": "PageMarginLandscapeNormal",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F579",
+    "Name": "PageMarginLandscapeModerate",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F57A",
+    "Name": "PageMarginLandscapeWide",
+    "Tags": [
+      "layout",
+      "document",
+      "balanced"
+    ]
+  },
+  {
+    "Code": "F57B",
+    "Name": "CollateLandscape",
+    "Tags": [
+      "document",
+      "pages",
+      "layout",
+      "orientation",
+      "printing"
+    ]
+  },
+  {
+    "Code": "F57C",
+    "Name": "CollatePortrait",
+    "Tags": [
+      "document",
+      "pages",
+      "layout",
+      "orientation",
+      "printing"
+    ]
+  },
+  {
+    "Code": "F57D",
+    "Name": "CollatePortraitSeparated",
+    "Tags": [
+      "document",
+      "pages",
+      "layout",
+      "orientation",
+      "printing"
+    ]
+  },
+  {
+    "Code": "F57E",
+    "Name": "DuplexLandscapeOneSided",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F57F",
+    "Name": "DuplexLandscapeOneSidedMirrored",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F580",
+    "Name": "DuplexLandscapeTwoSidedLongEdge",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F581",
+    "Name": "DuplexLandscapeTwoSidedLongEdgeMirrored",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F582",
+    "Name": "DuplexLandscapeTwoSidedShortEdge",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F583",
+    "Name": "DuplexLandscapeTwoSidedShortEdgeMirrored",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F584",
+    "Name": "DuplexPortraitOneSided",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F585",
+    "Name": "DuplexPortraitOneSidedMirrored",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F586",
+    "Name": "DuplexPortraitTwoSidedLongEdge",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F587",
+    "Name": "DuplexPortraitTwoSidedLongEdgeMirrored",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F588",
+    "Name": "DuplexPortraitTwoSidedShortEdge",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F589",
+    "Name": "DuplexPortraitTwoSidedShortEdgeMirrored",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F58A",
+    "Name": "PPSOneLandscape",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F58B",
+    "Name": "PPSTwoLandscape",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F58C",
+    "Name": "PPSTwoPortrait",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F58D",
+    "Name": "PPSFourLandscape",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F58E",
+    "Name": "PPSFourPortrait",
+    "Tags": [
+      "pages",
+      "printing",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F58F",
+    "Name": "HolePunchOff",
+    "Tags": [
+      "pages",
+      "printing",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F590",
+    "Name": "HolePunchPortraitLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper",
+      "office"
+    ]
+  },
+  {
+    "Code": "F591",
+    "Name": "HolePunchPortraitRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper",
+      "office"
+    ]
+  },
+  {
+    "Code": "F592",
+    "Name": "HolePunchPortraitTop",
+    "Tags": [
+      "binding",
+      "document",
+      "paper",
+      "office"
+    ]
+  },
+  {
+    "Code": "F593",
+    "Name": "HolePunchPortraitBottom",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F594",
+    "Name": "HolePunchLandscapeLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F595",
+    "Name": "HolePunchLandscapeRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F596",
+    "Name": "HolePunchLandscapeTop",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F597",
+    "Name": "HolePunchLandscapeBottom",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F598",
+    "Name": "StaplingOff",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F599",
+    "Name": "StaplingPortraitTopLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F59A",
+    "Name": "StaplingPortraitTopRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F59B",
+    "Name": "StaplingPortraitBottomRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F59C",
+    "Name": "StaplingPortraitTwoLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F59D",
+    "Name": "StaplingPortraitTwoRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F59E",
+    "Name": "StaplingPortraitTwoTop",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F59F",
+    "Name": "StaplingPortraitTwoBottom",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A0",
+    "Name": "StaplingPortraitBookBinding",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A1",
+    "Name": "StaplingLandscapeTopLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A2",
+    "Name": "StaplingLandscapeTopRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A3",
+    "Name": "StaplingLandscapeBottomLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A4",
+    "Name": "StaplingLandscapeBottomRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A5",
+    "Name": "StaplingLandscapeTwoLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A6",
+    "Name": "StaplingLandscapeTwoRight",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A7",
+    "Name": "StaplingLandscapeTwoTop",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A8",
+    "Name": "StaplingLandscapeTwoBottom",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5A9",
+    "Name": "StaplingLandscapeBookBinding",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5AA",
+    "Name": "StatusDataTransferRoaming",
+    "Tags": [
+      "connection",
+      "mobile",
+      "network",
+      "signal"
+    ]
+  },
+  {
+    "Code": "F5AB",
+    "Name": "MobSIMError",
+    "Tags": [
+      "x",
+      "problem",
+      "failure",
+      "alert"
+    ]
+  },
+  {
+    "Code": "F5AC",
+    "Name": "CollateLandscapeSeparated",
+    "Tags": [
+      "document",
+      "pages",
+      "layout",
+      "orientation",
+      "printing"
+    ]
+  },
+  {
+    "Code": "F5AD",
+    "Name": "PPSOnePortrait",
+    "Tags": [
+      "printing",
+      "pages",
+      "layout",
+      "orientation"
+    ]
+  },
+  {
+    "Code": "F5AE",
+    "Name": "StaplingPortraitBottomLeft",
+    "Tags": [
+      "binding",
+      "document",
+      "paper"
+    ]
+  },
+  {
+    "Code": "F5B0",
+    "Name": "PlaySolid",
+    "Tags": [
+      "control",
+      "playback",
+      "start",
+      "begin"
+    ]
+  },
+  {
+    "Code": "F5E7",
+    "Name": "RepeatOff",
+    "Tags": [
+      "arrow",
+      "audio",
+      "music",
+      "playback",
+      "control",
+      "media"
+    ]
+  },
+  {
+    "Code": "F5ED",
+    "Name": "Set",
+    "Tags": [
+      "configuration",
+      "settings",
+      "option",
+      "control",
+      "adjustment"
+    ]
+  },
+  {
+    "Code": "F5EE",
+    "Name": "SetSolid",
+    "Tags": [
+      "configuration",
+      "settings",
+      "option",
+      "control",
+      "adjustment"
+    ]
+  },
+  {
+    "Code": "F5EF",
+    "Name": "FuzzyReading",
+    "Tags": [
+      "blurred",
+      "unclear",
+      "vision",
+      "focus",
+      "interpretation"
+    ]
+  },
+  {
+    "Code": "F5F2",
+    "Name": "VerticalBattery0",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F3",
+    "Name": "VerticalBattery1",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F4",
+    "Name": "VerticalBattery2",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F5",
+    "Name": "VerticalBattery3",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F6",
+    "Name": "VerticalBattery4",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F7",
+    "Name": "VerticalBattery5",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F8",
+    "Name": "VerticalBattery6",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5F9",
+    "Name": "VerticalBattery7",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5FA",
+    "Name": "VerticalBattery8",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5FB",
+    "Name": "VerticalBattery9",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5FC",
+    "Name": "VerticalBattery10",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5FD",
+    "Name": "VerticalBatteryCharging0",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5FE",
+    "Name": "VerticalBatteryCharging1",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F5FF",
+    "Name": "VerticalBatteryCharging2",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F600",
+    "Name": "VerticalBatteryCharging3",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F601",
+    "Name": "VerticalBatteryCharging4",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F602",
+    "Name": "VerticalBatteryCharging5",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F603",
+    "Name": "VerticalBatteryCharging6",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F604",
+    "Name": "VerticalBatteryCharging7",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F605",
+    "Name": "VerticalBatteryCharging8",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F606",
+    "Name": "VerticalBatteryCharging9",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F607",
+    "Name": "VerticalBatteryCharging10",
+    "Tags": [
+      "charge",
+      "power"
+    ]
+  },
+  {
+    "Code": "F608",
+    "Name": "VerticalBatteryUnknown",
+    "Tags": [
+      "charge",
+      "power",
+      "status"
+    ]
+  },
+  {
+    "Code": "F618",
+    "Name": "SIMError",
+    "Tags": [
+      "problem",
+      "connection",
+      "mobile",
+      "network",
+      "issue"
+    ]
+  },
+  {
+    "Code": "F619",
+    "Name": "SIMMissing",
+    "Tags": [
+      "absent",
+      "connection",
+      "mobile",
+      "network",
+      "problem"
+    ]
+  },
+  {
+    "Code": "F61A",
+    "Name": "SIMLock",
+    "Tags": [
+      "security",
+      "mobile",
+      "network",
+      "protection",
+      "restriction"
+    ]
+  },
+  {
+    "Code": "F61B",
+    "Name": "eSIM",
+    "Tags": [
+      "virtual",
+      "SIM",
+      "mobile",
+      "connection",
+      "network",
+      "technology"
+    ]
+  },
+  {
+    "Code": "F61C",
+    "Name": "eSIMNoProfile",
+    "Tags": [
+      "missing",
+      "mobile",
+      "network",
+      "connection",
+      "problem"
+    ]
+  },
+  {
+    "Code": "F61D",
+    "Name": "eSIMLocked",
+    "Tags": [
+      "security",
+      "mobile",
+      "network",
+      "restriction",
+      "protection"
+    ]
+  },
+  {
+    "Code": "F61E",
+    "Name": "eSIMBusy",
+    "Tags": [
+      "active",
+      "mobile",
+      "network",
+      "connection",
+      "status"
+    ]
+  },
+  {
+    "Code": "F61F",
+    "Name": "NoiseCancelation",
+    "Tags": [
+      "sound",
+      "quiet",
+      "audio",
+      "filter",
+      "technology"
+    ]
+  },
+  {
+    "Code": "F620",
+    "Name": "NoiseCancelationOff",
+    "Tags": [
+      "sound",
+      "quiet",
+      "audio",
+      "filter",
+      "technology"
+    ]
+  },
+  {
+    "Code": "F623",
+    "Name": "MusicSharing",
+    "Tags": [
+      "audio",
+      "streaming",
+      "sound",
+      "media",
+      "connect"
+    ]
+  },
+  {
+    "Code": "F624",
+    "Name": "MusicSharingOff",
+    "Tags": [
+      "audio",
+      "streaming",
+      "sound",
+      "media",
+      "disconnect"
+    ]
+  },
+  {
+    "Code": "F63C",
+    "Name": "CircleShapeSolid",
+    "Tags": []
+  },
+  {
+    "Code": "F657",
+    "Name": "WifiCallBars",
+    "Tags": [
+      "signal",
+      "network",
+      "connection",
+      "communication"
+    ]
+  },
+  {
+    "Code": "F658",
+    "Name": "WifiCall0",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication"
+    ]
+  },
+  {
+    "Code": "F659",
+    "Name": "WifiCall1",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication"
+    ]
+  },
+  {
+    "Code": "F65A",
+    "Name": "WifiCall2",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication"
+    ]
+  },
+  {
+    "Code": "F65B",
+    "Name": "WifiCall3",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication"
+    ]
+  },
+  {
+    "Code": "F65C",
+    "Name": "WifiCall4",
+    "Tags": [
+      "bars",
+      "signal",
+      "network",
+      "connection",
+      "communication"
+    ]
+  },
+  {
+    "Code": "F67B",
+    "Name": "Pen",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F683",
+    "Name": "TextSelect",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F684",
+    "Name": "TextNavigate",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F698",
+    "Name": "PinyinIMELogo2",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F69B",
+    "Name": "UserRemove",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F69E",
+    "Name": "CHTLanguageBar",
+    "Tags": [
+      "input",
+      "keyboard",
+      "settings",
+      "switch",
+      "selection"
+    ]
+  },
+  {
+    "Code": "F6A9",
+    "Name": "ComposeMode",
+    "Tags": [
+      "create",
+      "writing",
+      "email",
+      "message",
+      "text",
+      "draft"
+    ]
+  },
+  {
+    "Code": "F6B8",
+    "Name": "ExpressiveInputEntry",
+    "Tags": [
+      "heart"
+    ]
+  },
+  {
+    "Code": "F6BA",
+    "Name": "EmojiTabMoreSymbols",
+    "Tags": [
+      "keyboard",
+      "expression",
+      "characters",
+      "emoticons",
+      "input"
+    ]
+  },
+  {
+    "Code": "F6C4",
+    "Name": "PhoneScreen",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F6C5",
+    "Name": "AlertUrgent",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F6C6",
+    "Name": "PhoneDesktop",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F6FA",
+    "Name": "WebSearch",
+    "Tags": [
+      "browser",
+      "internet",
+      "query",
+      "find",
+      "explore",
+      "online"
+    ]
+  },
+  {
+    "Code": "F712",
+    "Name": "Kiosk",
+    "Tags": [
+      "machine",
+      "interactive",
+      "self service",
+      "display",
+      "screen",
+      "stand",
+      "service"
+    ]
+  },
+  {
+    "Code": "F714",
+    "Name": "RTTLogo",
+    "Tags": [
+      "telecommunication",
+      "relay",
+      "service",
+      "call"
+    ]
+  },
+  {
+    "Code": "F715",
+    "Name": "VoiceCall",
+    "Tags": [
+      "phone",
+      "communication",
+      "phone",
+      "audio",
+      "telephone",
+      "talk",
+      "voicechat"
+    ]
+  },
+  {
+    "Code": "F716",
+    "Name": "GoToMessage",
+    "Tags": [
+      "chat",
+      "notification",
+      "communication",
+      "app",
+      "jump",
+      "shortcut"
+    ]
+  },
+  {
+    "Code": "F71A",
+    "Name": "ReturnToCall",
+    "Tags": [
+      "arrow",
+      "communication",
+      "phone",
+      "resume",
+      "connect",
+      "audio",
+      "ongoing"
+    ]
+  },
+  {
+    "Code": "F71C",
+    "Name": "StartPresenting",
+    "Tags": [
+      "share",
+      "screen",
+      "display",
+      "show",
+      "presentation",
+      "startshare"
+    ]
+  },
+  {
+    "Code": "F71D",
+    "Name": "StopPresenting",
+    "Tags": [
+      "share",
+      "screen",
+      "end",
+      "presentation",
+      "finish",
+      "shareend"
+    ]
+  },
+  {
+    "Code": "F71E",
+    "Name": "ProductivityMode",
+    "Tags": [
+      "focus",
+      "efficiency",
+      "work",
+      "task",
+      "performance",
+      "organization"
+    ]
+  },
+  {
+    "Code": "F738",
+    "Name": "SetHistoryStatus",
+    "Tags": [
+      "clock",
+      "update",
+      "record",
+      "track",
+      "log",
+      "change"
+    ]
+  },
+  {
+    "Code": "F739",
+    "Name": "SetHistoryStatus2",
+    "Tags": [
+      "clock",
+      "update",
+      "record",
+      "track",
+      "log",
+      "change"
+    ]
+  },
+  {
+    "Code": "F73D",
+    "Name": "Keyboardsettings20",
+    "Tags": [
+      "preferences",
+      "adjust",
+      "controls",
+      "configuration",
+      "customization"
+    ]
+  },
+  {
+    "Code": "F73E",
+    "Name": "OneHandedRight20",
+    "Tags": [
+      "keyboard",
+      "phone",
+      "gesture",
+      "adjustment",
+      "mode",
+      "easy"
+    ]
+  },
+  {
+    "Code": "F73F",
+    "Name": "OneHandedLeft20",
+    "Tags": [
+      "keyboard",
+      "phone",
+      "gesture",
+      "adjustment",
+      "mode",
+      "easy"
+    ]
+  },
+  {
+    "Code": "F740",
+    "Name": "Split20",
+    "Tags": [
+      "keyboard",
+      "phone",
+      "gesture",
+      "adjustment",
+      "mode",
+      "easy"
+    ]
+  },
+  {
+    "Code": "F741",
+    "Name": "Full20",
+    "Tags": [
+      "keyboard",
+      "phone",
+      "gesture",
+      "adjustment",
+      "mode",
+      "easy"
+    ]
+  },
+  {
+    "Code": "F742",
+    "Name": "Handwriting20",
+    "Tags": [
+      "pen",
+      "input",
+      "write",
+      "stylus",
+      "note",
+      "draw",
+      "sketch"
+    ]
+  },
+  {
+    "Code": "F743",
+    "Name": "ChevronLeft20",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "F744",
+    "Name": "ChevronLeft32",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "F745",
+    "Name": "ChevronRight20",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "F746",
+    "Name": "ChevronRight32",
+    "Tags": [
+      "arrow",
+      "direction",
+      "navigation"
+    ]
+  },
+  {
+    "Code": "F763",
+    "Name": "Event12",
+    "Tags": [
+      "calendar",
+      "date",
+      "schedule",
+      "meeting",
+      "reminder",
+      "occasion",
+      "activity"
+    ]
+  },
+  {
+    "Code": "F781",
+    "Name": "MicOff2",
+    "Tags": [
+      "microphone",
+      "mute",
+      "audio",
+      "silent",
+      "disabled"
+    ]
+  },
+  {
+    "Code": "F785",
+    "Name": "DeliveryOptimization",
+    "Tags": [
+      "network",
+      "update",
+      "performance",
+      "data",
+      "speed",
+      "efficiency"
+    ]
+  },
+  {
+    "Code": "F78A",
+    "Name": "CancelMedium",
+    "Tags": [
+      "x",
+      "close",
+      "stop",
+      "exit",
+      "abort",
+      "reject"
+    ]
+  },
+  {
+    "Code": "F78B",
+    "Name": "SearchMedium",
+    "Tags": [
+      "magnifying glass",
+      "zoom",
+      "inspect",
+      "review"
+    ]
+  },
+  {
+    "Code": "F78C",
+    "Name": "AcceptMedium",
+    "Tags": [
+      "check",
+      "agree",
+      "approve",
+      "confirm",
+      "approve"
+    ]
+  },
+  {
+    "Code": "F78D",
+    "Name": "RevealPasswordMedium",
+    "Tags": [
+      "security",
+      "visibility",
+      "protection",
+      "access"
+    ]
+  },
+  {
+    "Code": "F7AD",
+    "Name": "DeleteWord",
+    "Tags": [
+      "remove",
+      "text",
+      "edit",
+      "backspace",
+      "typing",
+      "content"
+    ]
+  },
+  {
+    "Code": "F7AE",
+    "Name": "DeleteWordFill",
+    "Tags": [
+      "remove",
+      "text",
+      "edit",
+      "backspace",
+      "typing",
+      "content"
+    ]
+  },
+  {
+    "Code": "F7AF",
+    "Name": "DeleteLines",
+    "Tags": [
+      "remove",
+      "text",
+      "edit",
+      "backspace",
+      "content",
+      "clear"
+    ]
+  },
+  {
+    "Code": "F7B0",
+    "Name": "DeleteLinesFill",
+    "Tags": [
+      "remove",
+      "text",
+      "edit",
+      "backspace",
+      "content",
+      "clear"
+    ]
+  },
+  {
+    "Code": "F7B1",
+    "Name": "InstertWords",
+    "Tags": [
+      "text",
+      "add",
+      "edit",
+      "content",
+      "typing",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "F7B2",
+    "Name": "InstertWordsFill",
+    "Tags": [
+      "text",
+      "add",
+      "edit",
+      "content",
+      "typing",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "F7B3",
+    "Name": "JoinWords",
+    "Tags": [
+      "combine",
+      "text",
+      "merge",
+      "edit",
+      "content",
+      "typing"
+    ]
+  },
+  {
+    "Code": "F7B4",
+    "Name": "JoinWordsFill",
+    "Tags": [
+      "combine",
+      "text",
+      "merge",
+      "edit",
+      "content",
+      "typing"
+    ]
+  },
+  {
+    "Code": "F7B5",
+    "Name": "OverwriteWords",
+    "Tags": [
+      "text",
+      "replace",
+      "edit",
+      "content",
+      "typing",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "F7B6",
+    "Name": "OverwriteWordsFill",
+    "Tags": [
+      "text",
+      "replace",
+      "edit",
+      "content",
+      "typing",
+      "keyboard"
+    ]
+  },
+  {
+    "Code": "F7B7",
+    "Name": "AddNewLine",
+    "Tags": [
+      "text",
+      "insert",
+      "edit",
+      "content",
+      "paragraph"
+    ]
+  },
+  {
+    "Code": "F7B8",
+    "Name": "AddNewLineFill",
+    "Tags": [
+      "text",
+      "insert",
+      "edit",
+      "content",
+      "paragraph"
+    ]
+  },
+  {
+    "Code": "F7B9",
+    "Name": "OverwriteWordsKorean",
+    "Tags": [
+      "text",
+      "replace",
+      "edit",
+      "content",
+      "typing"
+    ]
+  },
+  {
+    "Code": "F7BA",
+    "Name": "OverwriteWordsFillKorean",
+    "Tags": [
+      "text",
+      "replace",
+      "edit",
+      "content",
+      "typing"
+    ]
+  },
+  {
+    "Code": "F7BB",
+    "Name": "EducationIcon",
+    "Tags": [
+      "pencil",
+      "write"
+    ]
+  },
+  {
+    "Code": "F7ED",
+    "Name": "WindowSnipping",
+    "Tags": [
+      "screenshot",
+      "capture",
+      "image",
+      "edit",
+      "select",
+      "tool"
+    ]
+  },
+  {
+    "Code": "F7EE",
+    "Name": "VideoCapture",
+    "Tags": [
+      "record",
+      "camera",
+      "film",
+      "content",
+      "media",
+      "capture"
+    ]
+  },
+  {
+    "Code": "F809",
+    "Name": "StatusSecured",
+    "Tags": [
+      "lock",
+      "security",
+      "protected",
+      "safe",
+      "encrypted",
+      "access"
+    ]
+  },
+  {
+    "Code": "F83B",
+    "Name": "NarratorApp",
+    "Tags": [
+      "accessibility",
+      "voice",
+      "screen reader",
+      "assistive",
+      "text to speech",
+      "reading"
+    ]
+  },
+  {
+    "Code": "F83D",
+    "Name": "PowerButtonUpdate",
+    "Tags": [
+      "on",
+      "off",
+      "restart",
+      "settings",
+      "system",
+      "computer",
+      "device"
+    ]
+  },
+  {
+    "Code": "F83E",
+    "Name": "RestartUpdate",
+    "Tags": [
+      "arrow",
+      "refresh",
+      "system",
+      "refresh",
+      "reboot",
+      "settings",
+      "install",
+      "software"
+    ]
+  },
+  {
+    "Code": "F83F",
+    "Name": "UpdateStatusDot",
+    "Tags": [
+      "notification",
+      "install",
+      "progress",
+      "indicator",
+      "software"
+    ]
+  },
+  {
+    "Code": "F847",
+    "Name": "Eject",
+    "Tags": [
+      "remove",
+      "disk",
+      "media",
+      "device",
+      "hardware",
+      "storage",
+      "button"
+    ]
+  },
+  {
+    "Code": "F87B",
+    "Name": "Spelling",
+    "Tags": [
+      "check",
+      "text",
+      "correction",
+      "language",
+      "grammar",
+      "proofreading",
+      "editor"
+    ]
+  },
+  {
+    "Code": "F87C",
+    "Name": "SpellingKorean",
+    "Tags": [
+      "check",
+      "text",
+      "correction",
+      "language",
+      "grammar",
+      "proofreading",
+      "editor"
+    ]
+  },
+  {
+    "Code": "F87D",
+    "Name": "SpellingSerbian",
+    "Tags": [
+      "check",
+      "text",
+      "correction",
+      "language",
+      "grammar",
+      "proofreading",
+      "editor"
+    ]
+  },
+  {
+    "Code": "F87E",
+    "Name": "SpellingChinese",
+    "Tags": [
+      "abc",
+      "check",
+      "text",
+      "correction",
+      "language",
+      "grammar",
+      "proofreading",
+      "editor"
+    ]
+  },
+  {
+    "Code": "F89A",
+    "Name": "FolderSelect",
+    "Tags": [
+      "file",
+      "directory",
+      "choose",
+      "browse",
+      "system",
+      "storage"
+    ]
+  },
+  {
+    "Code": "F8A5",
+    "Name": "SmartScreen",
+    "Tags": [
+      "protection",
+      "security",
+      "filter",
+      "safe",
+      "web",
+      "browser"
+    ]
+  },
+  {
+    "Code": "F8A6",
+    "Name": "ExploitProtection",
+    "Tags": [
+      "security",
+      "vulnerability",
+      "threat",
+      "shield",
+      "software",
+      "defense"
+    ]
+  },
+  {
+    "Code": "F8AA",
+    "Name": "AddBold",
+    "Tags": [
+      "+",
+      "plus",
+      "addition",
+      "new"
+    ]
+  },
+  {
+    "Code": "F8AB",
+    "Name": "SubtractBold",
+    "Tags": [
+      "-"
+    ]
+  },
+  {
+    "Code": "F8AC",
+    "Name": "BackSolidBold",
+    "Tags": [
+      "arrow",
+      "previous",
+      "return",
+      "left",
+      "rewind"
+    ]
+  },
+  {
+    "Code": "F8AD",
+    "Name": "ForwardSolidBold",
+    "Tags": [
+      "arrow",
+      "next",
+      "send",
+      "right",
+      "proceed"
+    ]
+  },
+  {
+    "Code": "F8AE",
+    "Name": "PauseBold",
+    "Tags": [
+      "control",
+      "playback",
+      "freeze"
+    ]
+  },
+  {
+    "Code": "F8AF",
+    "Name": "ClickSolid",
+    "Tags": [
+      "pointer",
+      "tap",
+      "press",
+      "select",
+      "activate",
+      "choose"
+    ]
+  },
+  {
+    "Code": "F8B0",
+    "Name": "SettingsSolid",
+    "Tags": [
+      "gear",
+      "options",
+      "cog"
+    ]
+  },
+  {
+    "Code": "F8B1",
+    "Name": "MicrophoneSolidBold",
+    "Tags": [
+      "audio",
+      "voice",
+      "record",
+      "sound",
+      "speech"
+    ]
+  },
+  {
+    "Code": "F8B2",
+    "Name": "SpeechSolidBold",
+    "Tags": [
+      "person",
+      "user",
+      "audio",
+      "talking"
+    ]
+  },
+  {
+    "Code": "F8B3",
+    "Name": "ClickedOutLoudSolidBold",
+    "Tags": [
+      "sound",
+      "audio",
+      "action",
+      "press",
+      "interaction",
+      "notification"
+    ]
+  },
+  {
+    "Code": "F8C0",
+    "Name": "VPNOverlay",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C1",
+    "Name": "VPNRoamingOverly",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C2",
+    "Name": "WifiVPN3",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C3",
+    "Name": "WifiVPN4",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C4",
+    "Name": "WifiVPN5",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C5",
+    "Name": "SignalBarsVPN2",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C6",
+    "Name": "SignalBarsVPN3",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C7",
+    "Name": "SignalBarsVPN4",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C8",
+    "Name": "SignalBarsVPN5",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8C9",
+    "Name": "SignalBarsVPNRoaming3",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8CA",
+    "Name": "SignalBarsVPNRoaming4",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8CB",
+    "Name": "SignalBarsVPNRoaming5",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  },
+  {
+    "Code": "F8CC",
+    "Name": "EthernetVPN",
+    "Tags": [],
+    "IsSegoeFluentOnly": true
+  }
+]

--- a/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/IconsDataSchema.json
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/DataModel/IconsDataSchema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "Code": {
+        "type": "string",
+        "description": "Glyph code",
+        "uniqueItems": true
+      },
+      "Name": {
+        "type": "string",
+        "description": "Name of the glyph",
+        "uniqueItems": true
+      },
+      "Tags": {
+        "type": "array",
+        "description": "Array of tags related to this glyph",
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      },
+      "IsSegoeFluentOnly": {
+        "type": "boolean",
+        "default": false,
+        "description": "Determines whether the icon is only available in Segoe Fluent Icons and not in Segoe MDL2 Assets."
+      }
+    },
+    "required": [
+      "Code",
+      "Name"
+    ]
+  }
+}

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Helpers/IconsDataSource.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Helpers/IconsDataSource.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using iNKORE.UI.WPF.Modern.Gallery.Models;
+
+namespace iNKORE.UI.WPF.Modern.Gallery.Helpers;
+
+internal class IconsDataSource
+{
+    public static IconsDataSource Instance { get; } = new();
+
+    public static List<IconData> Icons => Instance.icons;
+
+    private List<IconData> icons = new();
+
+    private IconsDataSource() { }
+
+    public object _lock = new();
+
+    public async Task<List<IconData>> LoadIcons()
+    {
+        lock (_lock)
+        {
+            if (icons.Count != 0)
+            {
+                return icons;
+            }
+        }
+
+        // Load from embedded resource
+        var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+        var resourceName = "iNKORE.UI.WPF.Modern.Gallery.DataModel.IconsData.json";
+
+        using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+        {
+            if (stream != null)
+            {
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    var jsonText = await reader.ReadToEndAsync();
+                    lock (_lock)
+                    {
+                        if (icons.Count == 0)
+                        {
+                            icons = JsonSerializer.Deserialize<List<IconData>>(jsonText);
+                        }
+                        return icons;
+                    }
+                }
+            }
+        }
+
+        // Fallback: try to load from file
+        var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "DataModel", "IconsData.json");
+        if (File.Exists(filePath))
+        {
+            var jsonText = await File.ReadAllTextAsync(filePath);
+            lock (_lock)
+            {
+                if (icons.Count == 0)
+                {
+                    icons = JsonSerializer.Deserialize<List<IconData>>(jsonText);
+                }
+                return icons;
+            }
+        }
+
+        return icons;
+    }
+}

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Helpers/IconsDataSource.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Helpers/IconsDataSource.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
-using iNKORE.UI.WPF.Modern.Gallery.Models;
+using iNKORE.UI.WPF.Modern.Gallery.DataModel;
 
 namespace iNKORE.UI.WPF.Modern.Gallery.Helpers;
 

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Navigation/NavigationRootPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Navigation/NavigationRootPage.xaml
@@ -122,6 +122,14 @@
                     </ui:NavigationViewItem.Icon>
                     <ui:NavigationViewItem.MenuItems>
                         <ui:NavigationViewItem
+                            x:Name="IconographyItem"
+                            Content="Iconography"
+                            Tag="Iconography">
+                            <ui:NavigationViewItem.Icon>
+                                <ui:FontIcon Glyph="&#xED58;" />
+                            </ui:NavigationViewItem.Icon>
+                        </ui:NavigationViewItem>
+                        <ui:NavigationViewItem
                             x:Name="TypographyItem"
                             Content="Typography"
                             Tag="Typography">

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Navigation/NavigationRootPage.xaml.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Navigation/NavigationRootPage.xaml.cs
@@ -293,19 +293,36 @@ namespace iNKORE.UI.WPF.Modern.Gallery
                     _lastItem = item;
                     rootFrame.Navigate(item);
                 }
+                else if (selectedItem?.Tag?.ToString() == "Iconography")
+                {
+                    var iconographyId = "Iconography";
+                    if (_lastItem?.ToString() == iconographyId) return;
+                    _lastItem = iconographyId;
+
+                    // Find Iconography item from the data source
+                    var iconographyItem = ControlInfoDataSource.Instance.Realms
+                        .SelectMany(r => r.Groups)
+                        .SelectMany(g => g.Items)
+                        .FirstOrDefault(i => i.UniqueId == "Iconography");
+
+                    if (iconographyItem != null)
+                    {
+                        rootFrame.Navigate(ItemPage.Create(iconographyItem));
+                    }
+                }
                 else if (selectedItem?.Tag?.ToString() == "Typography")
                 {
                     // Handle Typography navigation
                     var typographyId = "Typography";
                     if (_lastItem?.ToString() == typographyId) return;
                     _lastItem = typographyId;
-                    
+
                     // Find Typography item from the data source
                     var typographyItem = ControlInfoDataSource.Instance.Realms
                         .SelectMany(r => r.Groups)
                         .SelectMany(g => g.Items)
                         .FirstOrDefault(i => i.UniqueId == "Typography");
-                    
+
                     if (typographyItem != null)
                     {
                         rootFrame.Navigate(ItemPage.Create(typographyItem));

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Foundation/Design/IconographyPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Foundation/Design/IconographyPage.xaml
@@ -1,0 +1,925 @@
+<!--  Copyright (c) Microsoft Corporation and Contributors.  -->
+<!--  Licensed under the MIT License.  -->
+
+<ui:Page x:Class="iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Foundation.IconographyPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:local="clr-namespace:iNKORE.UI.WPF.Modern.Gallery"
+    xmlns:models="clr-namespace:iNKORE.UI.WPF.Modern.Gallery.DataModel"
+      xmlns:helpers="clr-namespace:iNKORE.UI.WPF.Modern.Gallery.Helpers"
+      xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
+      x:Name="iconographyPage"
+      mc:Ignorable="d">
+
+    <ui:Page.Resources>
+        <DataTemplate x:Key="IconTemplate" DataType="{x:Type models:IconData}">
+            <Border Width="96" Height="96" CornerRadius="{DynamicResource ControlCornerRadius}" ToolTipService.ToolTip="{Binding Name}">
+                <Border Background="{DynamicResource CardBackgroundFillColorDefaultBrush}" BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="1" CornerRadius="{DynamicResource ControlCornerRadius}">
+                    <Grid>
+                        <Viewbox Width="28" Height="28" Margin="0,0,0,16" Stretch="Uniform">
+                            <TextBlock x:Name="IconGlyph" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{Binding Character}" Foreground="{DynamicResource TextFillColorPrimaryBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center"/>
+                        </Viewbox>
+                        <TextBlock x:Name="IconName" Margin="8,0,8,8" HorizontalAlignment="Center" VerticalAlignment="Bottom" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{DynamicResource CaptionTextBlockStyle}" Text="{Binding Name}" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" />
+                    </Grid>
+                </Border>
+            </Border>
+        </DataTemplate>
+
+        <!-- Local tag chip Button style: uses a simple Border in the ControlTemplate
+             and only changes visual properties that do not affect layout (opacity).
+             This preserves keyboard/automation semantics of Button while avoiding
+             measured-size changes from system Button templates. -->
+        <Style x:Key="TagChipButtonStyle" TargetType="Button">
+            <!-- Button is the single visual for the chip: background, border, corner radius -->
+            <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorDefaultBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefaultBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="10,4" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="MinWidth" Value="44" />
+            <Setter Property="MinHeight" Value="24" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="RootBorder"
+                                MinHeight="24"
+                                MinWidth="44"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="12"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter x:Name="contentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Margin="0"
+                                              RecognizesAccessKey="True"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="RootBorder" Property="Opacity" Value="0.95" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="RootBorder" Property="Opacity" Value="0.85" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="RootBorder" Property="Opacity" Value="0.5" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+    </ui:Page.Resources>
+
+    <!--
+        VisualStateManager groups live on the top-level LayoutRoot so
+        VisualStateManager.GoToElementState(LayoutRoot, "StateName", true)
+        can find and activate the states. Keep animation target element
+        names unique and in the same namescope as LayoutRoot so Storyboards
+        can resolve them at runtime.
+    -->
+    <Grid x:Name="LayoutRoot">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+    <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="ControlCornerRadiusCopyButtonStates">
+                <VisualState x:Name="ControlCornerRadiusCopyButtonHidden">
+                    <Storyboard>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                         Storyboard.TargetName="FontIcon_ControlCornerRadiusCopyButton_Success"
+                                         Storyboard.TargetProperty="Opacity"/>
+                        <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                         Storyboard.TargetName="ScaleTransform_ControlCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="ScaleX"/>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                         Storyboard.TargetName="FontIcon_ControlCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="Opacity"/>
+                    </Storyboard>
+                </VisualState>
+                <VisualState x:Name="ControlCornerRadiusCopyButtonVisible">
+                    <Storyboard>
+                        <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                         Storyboard.TargetName="ScaleTransform_ControlCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="ScaleX"/>
+                        <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                         Storyboard.TargetName="FontIcon_ControlCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="Opacity"/>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                         Storyboard.TargetName="ScaleTransform_ControlCornerRadiusCopyButton_Success"
+                                         Storyboard.TargetProperty="ScaleX">
+                            <DoubleAnimation.EasingFunction>
+                                <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                            </DoubleAnimation.EasingFunction>
+                        </DoubleAnimation>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                         Storyboard.TargetName="FontIcon_ControlCornerRadiusCopyButton_Success"
+                                         Storyboard.TargetProperty="Opacity"/>
+                    </Storyboard>
+                </VisualState>
+            </VisualStateGroup>
+                <!-- Per-button copy visual states for side-panel copy buttons.
+                     Each group targets the named FontIcon/ScaleTransform elements
+                     that are defined alongside each Button below. The code-behind
+                     will compute the state name from the clicked Button's x:Name
+                     (e.g. Button x:Name="CopyXamlButton" -> state "CopyXamlVisible"). -->
+                <VisualStateGroup x:Name="CopyNameButtonStates">
+                    <VisualState x:Name="CopyNameHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyName_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyName_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyName_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopyNameVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopyName_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyName_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyName_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyName_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopyTextGlyphButtonStates">
+                    <VisualState x:Name="CopyTextGlyphHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyTextGlyph_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyTextGlyph_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyTextGlyph_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopyTextGlyphVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopyTextGlyph_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyTextGlyph_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyTextGlyph_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyTextGlyph_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopyCodeGlyphButtonStates">
+                    <VisualState x:Name="CopyCodeGlyphHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyCodeGlyph_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyCodeGlyph_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyCodeGlyph_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopyCodeGlyphVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopyCodeGlyph_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyCodeGlyph_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyCodeGlyph_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyCodeGlyph_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopyXamlButtonStates">
+                    <VisualState x:Name="CopyXamlHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyXaml_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyXaml_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyXaml_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopyXamlVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopyXaml_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyXaml_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyXaml_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyXaml_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopyInlineExampleButtonStates">
+                    <VisualState x:Name="CopyInlineExampleHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyInlineExample_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyInlineExample_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyInlineExample_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopyInlineExampleVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopyInlineExample_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyInlineExample_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyInlineExample_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyInlineExample_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopyCSharpButtonStates">
+                    <VisualState x:Name="CopyCSharpHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyCSharp_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyCSharp_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyCSharp_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopyCSharpVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopyCSharp_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopyCSharp_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopyCSharp_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopyCSharp_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopySymbolXamlButtonStates">
+                    <VisualState x:Name="CopySymbolXamlHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolXaml_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopySymbolXaml_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolXaml_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopySymbolXamlVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopySymbolXaml_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolXaml_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopySymbolXaml_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolXaml_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+                <VisualStateGroup x:Name="CopySymbolCSharpButtonStates">
+                    <VisualState x:Name="CopySymbolCSharpHidden">
+                        <Storyboard>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolCSharp_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopySymbolCSharp_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolCSharp_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="CopySymbolCSharpVisible">
+                        <Storyboard>
+                            <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                             Storyboard.TargetName="ScaleTransform_CopySymbolCSharp_Copy"
+                                             Storyboard.TargetProperty="ScaleX"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolCSharp_Copy"
+                                             Storyboard.TargetProperty="Opacity"/>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                             Storyboard.TargetName="ScaleTransform_CopySymbolCSharp_Success"
+                                             Storyboard.TargetProperty="ScaleX">
+                                <DoubleAnimation.EasingFunction>
+                                    <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                            <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                             Storyboard.TargetName="FontIcon_CopySymbolCSharp_Success"
+                                             Storyboard.TargetProperty="Opacity"/>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+            <VisualStateGroup x:Name="OverlayCornerRadiusCopyButtonStates">
+                <VisualState x:Name="OverlayCornerRadiusCopyButtonHidden">
+                    <Storyboard>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="0" 
+                                         Storyboard.TargetName="FontIcon_OverlayCornerRadiusCopyButton_Success"
+                                         Storyboard.TargetProperty="Opacity"/>
+                        <DoubleAnimation Duration="00:00:00:0" To="1" 
+                                         Storyboard.TargetName="ScaleTransform_OverlayCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="ScaleX"/>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                         Storyboard.TargetName="FontIcon_OverlayCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="Opacity"/>
+                    </Storyboard>
+                </VisualState>
+                <VisualState x:Name="OverlayCornerRadiusCopyButtonVisible">
+                    <Storyboard>
+                        <DoubleAnimation Duration="00:00:00:0.15" To="0" 
+                                         Storyboard.TargetName="ScaleTransform_OverlayCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="ScaleX"/>
+                        <DoubleAnimation BeginTime="00:00:00:0.1" Duration="00:00:00:0.01" To="0" 
+                                         Storyboard.TargetName="FontIcon_OverlayCornerRadiusCopyButton_Copy"
+                                         Storyboard.TargetProperty="Opacity"/>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.15" To="1" 
+                                         Storyboard.TargetName="ScaleTransform_OverlayCornerRadiusCopyButton_Success"
+                                         Storyboard.TargetProperty="ScaleX">
+                            <DoubleAnimation.EasingFunction>
+                                <BackEase EasingMode="EaseOut" Amplitude="0.2"/>
+                            </DoubleAnimation.EasingFunction>
+                        </DoubleAnimation>
+                        <DoubleAnimation BeginTime="00:00:00:0.15" Duration="00:00:00:0.015" To="1" 
+                                         Storyboard.TargetName="FontIcon_OverlayCornerRadiusCopyButton_Success"
+                                         Storyboard.TargetProperty="Opacity"/>
+                    </Storyboard>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+    <StackPanel Grid.Row="0" Orientation="Vertical">
+    <ui:SettingsExpander Margin="0,0,0,20" Header="How to use Segoe Fluent Icons">
+        <ui:SettingsExpander.Items>
+            <ui:SettingsCard Header="How to get the font" FontWeight="SemiBold">
+                <ui:SettingsCard.Description>
+                    <TextBlock Margin="0,0,0,0" TextWrapping="Wrap" FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                        Segoe Fluent Icons comes preinstalled on Windows 11. On Windows 10, it requires a manual installation. You can download it
+                        <InlineUIContainer BaselineAlignment="Center">
+                            <!-- The hyperlink under the settings expander text was not automatically 
+                            styled in Fluent style, so we used a hyperlink button instead. -->
+                            <ui:HyperlinkButton
+                                               NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts"
+                                               VerticalAlignment="Center"
+                                               VerticalContentAlignment="Center"
+                                               Padding="0,1,0,0"
+                                               FontWeight="Normal"
+                                               FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                                               FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                                <TextBlock Text="here"
+                                           TextDecorations="Underline"
+                                           FontWeight="Normal"
+                                           FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                                           FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}" />
+                            </ui:HyperlinkButton>
+                        </InlineUIContainer>.
+                    </TextBlock>
+                </ui:SettingsCard.Description>
+            </ui:SettingsCard>
+
+            <ui:SettingsCard Header="How to use" FontWeight="SemiBold">
+                <ui:SettingsCard.Description>
+                    <StackPanel Orientation="Vertical" Margin="0">
+                        <TextBlock Margin="0,0,0,0" TextWrapping="Wrap" FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                            If you don't specify a FontFamily, or you specify a FontFamily that is not available on the system at runtime, a
+                            <InlineUIContainer BaselineAlignment="Center">
+                                <ui:HyperlinkButton
+                                                   NavigateUri="https://learn.microsoft.com/windows/apps/design/controls/font-icon"
+                                                   VerticalAlignment="Center"
+                                                   VerticalContentAlignment="Center"
+                                                   Padding="0,1,0,0"
+                                                   FontWeight="Normal"
+                                                   FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                                                   FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                                    <TextBlock Text="FontIcon"
+                                               TextDecorations="Underline"
+                                               FontWeight="Normal"
+                                               FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                                               FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}" />
+                                </ui:HyperlinkButton>
+                            </InlineUIContainer> falls back to the default font family defined by the SymbolThemeFontFamily resource.
+                        </TextBlock>
+
+                        <TextBlock Margin="0,0,0,0" TextWrapping="Wrap" FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                            An icon with a 16-epx font size is the equivalent of a 16x16-epx icon, to make sizing and positioning more predictable. For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
+                        </TextBlock>
+
+                        <TextBlock Margin="0,0,0,0" TextWrapping="Wrap" FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                            All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so
+                            <InlineUIContainer BaselineAlignment="Center">
+                                 <!-- The hyperlink under the settings expander text was not automatically
+                                styled in Fluent style, so we used a hyperlink button instead. -->
+                                <ui:HyperlinkButton
+                                                   NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring"
+                                                   VerticalAlignment="Center"
+                                                   VerticalContentAlignment="Center"
+                                                   Padding="0,1,0,0"
+                                                   FontWeight="Normal"
+                                                   FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                                                   FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}">
+                                    <TextBlock Text="layering"
+                                               TextDecorations="Underline"
+                                               FontWeight="Normal"
+                                               FontFamily="{DynamicResource ContentControlThemeFontFamily}"
+                                               FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}" />
+                                </ui:HyperlinkButton>
+                            </InlineUIContainer>
+                            and colorization effects can be achieved by drawing glyphs directly on top of each other.
+                        </TextBlock>
+
+                            <Grid HorizontalAlignment="Stretch">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBox Grid.Row="0" Grid.Column="0" x:Name="InlineExampleBox" Margin="0" FontFamily="Consolas" FontSize="{DynamicResource {x:Static ui:ThemeKeys.BodyTextBlockFontSizeKey}}" FontWeight="Normal" IsReadOnly="True" Background="Transparent" BorderThickness="0" Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                     AcceptsReturn="True" AcceptsTab="True" TextWrapping="NoWrap" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" MinHeight="72" xml:space="preserve" TextAlignment="Left"
+                                     HorizontalAlignment="Stretch"
+                                     Text="&lt;Grid&gt;&#x0A;    &lt;FontIcon Glyph=&quot;&amp;#xEB51;&quot; Foreground=&quot;#C72335&quot; /&gt;&#x0A;    &lt;FontIcon Glyph=&quot;&amp;#xEB52;&quot; /&gt;&#x0A;&lt;/Grid&gt;" />
+                            <Button x:Name="CopyInlineExampleButton" Grid.Row="0" Grid.Column="1" Margin="8,0,8,20" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding Text, ElementName=InlineExampleBox}">
+                                <Grid>
+                                    <ui:FontIcon x:Name="FontIcon_CopyInlineExample_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                        <FrameworkElement.RenderTransform>
+                                            <ScaleTransform x:Name="ScaleTransform_CopyInlineExample_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                        </FrameworkElement.RenderTransform>
+                                    </ui:FontIcon>
+                                    <ui:FontIcon x:Name="FontIcon_CopyInlineExample_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5" Opacity="0">
+                                        <FrameworkElement.RenderTransform>
+                                            <ScaleTransform x:Name="ScaleTransform_CopyInlineExample_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                        </FrameworkElement.RenderTransform>
+                                    </ui:FontIcon>
+                                </Grid>
+                            </Button>
+                        </Grid>
+                    </StackPanel>
+                </ui:SettingsCard.Description>
+            </ui:SettingsCard>
+        </ui:SettingsExpander.Items>
+    </ui:SettingsExpander>
+
+    <ui:AutoSuggestBox
+        x:Name="IconsSearchBox"
+        MinWidth="304"
+        MaxWidth="320"
+        HorizontalAlignment="Left"
+        Margin="0,16,0,10"
+        PlaceholderText="Search icons by name, code, or tags"
+        TextChanged="SearchTextBox_TextChanged">
+        <ui:AutoSuggestBox.Header>
+            <TextBlock Text="Fluent Icons Library" FontWeight="SemiBold" />
+        </ui:AutoSuggestBox.Header>
+        <ui:AutoSuggestBox.QueryIcon>
+            <ui:FontIcon Icon="{x:Static ui:SegoeFluentIcons.Search}" />
+        </ui:AutoSuggestBox.QueryIcon>
+    </ui:AutoSuggestBox>
+</StackPanel>
+
+    <Border x:Name="ExampleContainerBorder" Grid.Row="1" Background="{DynamicResource ControlExampleDisplayBrush}" CornerRadius="8" MaxHeight="600">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="334" />
+                </Grid.ColumnDefinitions>
+
+                <ui:ItemsRepeaterScrollHost>
+                    <!-- Disable horizontal scrolling so the repeater is constrained to the page width
+                         and the FlowLayout can wrap items correctly. Keep vertical scrolling enabled. -->
+                    <ui:ScrollViewerEx HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                        <ui:ItemsRepeater x:Name="IconsItemsView" Margin="10" HorizontalAlignment="Stretch">
+                        <ui:ItemsRepeater.ItemTemplate>
+                            <DataTemplate>
+                                <Button
+                                    Margin="4"
+                                    Tag="IconItemContainer"
+                                    Click="IconsItemsView_ItemClicked"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center">
+                                    <ContentControl Content="{Binding}" ContentTemplate="{StaticResource IconTemplate}" />
+                                </Button>
+                            </DataTemplate>
+                        </ui:ItemsRepeater.ItemTemplate>
+
+                        <ui:ItemsRepeater.Layout>
+                            <ui:FlowLayout Orientation="Horizontal" MinColumnSpacing="8" MinRowSpacing="6" />
+                        </ui:ItemsRepeater.Layout>
+                        </ui:ItemsRepeater>
+                    </ui:ScrollViewerEx>
+                </ui:ItemsRepeaterScrollHost>
+
+                <Border x:Name="SidePanel" Grid.Column="1" Background="{DynamicResource CardBackgroundFillColorDefaultBrush}" BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}" BorderThickness="{DynamicResource ControlExampleDisplayBorderThickness}" DataContext="{Binding}" CornerRadius="0,8,8,0" Visibility="Collapsed">
+                    <ScrollViewer>
+                        <StackPanel Margin="16,16,8,16" >
+                            <Grid Margin="0,0,0,24" HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <Border Margin="0,0,8,0" Padding="8" HorizontalAlignment="Left">
+                                    <TextBlock FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="48" Text="{Binding SelectedItem.Character, Mode=OneWay}" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+                                </Border>
+                                <Grid Grid.Column="1" HorizontalAlignment="Stretch" Visibility="Collapsed">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                </Grid>
+                            </Grid>
+
+                            <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="Icon name" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SelectedItem.Name, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                                         FontSize="{DynamicResource ControlContentThemeFontSize}"
+                                                         IsReadOnly="True"
+                                                         BorderThickness="0"
+                                                         Background="Transparent"
+                                                         IsReadOnlyCaretVisible="False"
+                                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                         TextAlignment="Left"
+                                                         VerticalAlignment="Center"
+                                                         VerticalContentAlignment="Center"
+                                                         HorizontalScrollBarVisibility="Hidden"
+                                                         TextWrapping="NoWrap"
+                                                         MinWidth="120" />
+                                <Button x:Name="CopyNameButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding SelectedItem.Name, Mode=OneWay}">
+                                    <Grid>
+                                        <ui:FontIcon x:Name="FontIcon_CopyName_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyName_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                        <ui:FontIcon x:Name="FontIcon_CopyName_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyName_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                    </Grid>
+                                </Button>
+                            </Grid>
+
+                            <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="Text glyph" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SelectedItem.TextGlyph, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                                         FontSize="{DynamicResource ControlContentThemeFontSize}"
+                                                         IsReadOnly="True"
+                                                         BorderThickness="0"
+                                                         Background="Transparent"
+                                                         IsReadOnlyCaretVisible="False"
+                                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                         TextAlignment="Left"
+                                                         VerticalAlignment="Center"
+                                                         VerticalContentAlignment="Center"
+                                                         HorizontalScrollBarVisibility="Hidden"
+                                                         TextWrapping="NoWrap"
+                                                         MinWidth="120"/>
+                                <Button x:Name="CopyTextGlyphButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding SelectedItem.TextGlyph, Mode=OneWay}">
+                                    <Grid>
+                                        <ui:FontIcon x:Name="FontIcon_CopyTextGlyph_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyTextGlyph_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                        <ui:FontIcon x:Name="FontIcon_CopyTextGlyph_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyTextGlyph_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                    </Grid>
+                                </Button>
+                            </Grid>
+
+                            <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="Code glyph" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{Binding SelectedItem.CodeGlyph, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                                         FontSize="{DynamicResource ControlContentThemeFontSize}"
+                                                         IsReadOnly="True"
+                                                         BorderThickness="0"
+                                                         Background="Transparent"
+                                                         IsReadOnlyCaretVisible="False"
+                                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                         TextAlignment="Left"
+                                                         VerticalAlignment="Center"
+                                                         VerticalContentAlignment="Center"
+                                                         HorizontalScrollBarVisibility="Hidden"
+                                                         TextWrapping="NoWrap"
+                                                         MinWidth="120"/>
+                                <Button x:Name="CopyCodeGlyphButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding SelectedItem.CodeGlyph, Mode=OneWay}">
+                                    <Grid>
+                                        <ui:FontIcon x:Name="FontIcon_CopyCodeGlyph_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyCodeGlyph_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                        <ui:FontIcon x:Name="FontIcon_CopyCodeGlyph_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyCodeGlyph_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                    </Grid>
+                                </Button>
+                            </Grid>
+
+                            <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="XAML" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="FontIconXamlBox" Text="{Binding FontIconXaml, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                         FontSize="12"
+                                         IsReadOnly="True"
+                                         AcceptsReturn="True"
+                                         AcceptsTab="True"
+                                         BorderThickness="0"
+                                         Background="Transparent"
+                                         IsReadOnlyCaretVisible="False"
+                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                         TextAlignment="Left"
+                                         VerticalAlignment="Center"
+                                         VerticalContentAlignment="Center"
+                                         HorizontalScrollBarVisibility="Auto"
+                                         VerticalScrollBarVisibility="Auto"
+                                         TextWrapping="Wrap"
+                                         MinWidth="120"
+                                         Padding="6"/>
+                                <Button x:Name="CopyXamlButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding FontIconXaml, Mode=OneWay}">
+                                    <Grid>
+                                        <ui:FontIcon x:Name="FontIcon_CopyXaml_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyXaml_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                        <ui:FontIcon x:Name="FontIcon_CopyXaml_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyXaml_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                    </Grid>
+                                </Button>
+                            </Grid>
+
+                            <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="C#" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="FontIconCSharpBox" Text="{Binding FontIconCSharp, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                         FontSize="12"
+                                         IsReadOnly="True"
+                                         AcceptsReturn="True"
+                                         AcceptsTab="True"
+                                         BorderThickness="0"
+                                         Background="Transparent"
+                                         IsReadOnlyCaretVisible="False"
+                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                         TextAlignment="Left"
+                                         VerticalAlignment="Center"
+                                         VerticalContentAlignment="Center"
+                                         HorizontalScrollBarVisibility="Auto"
+                                         VerticalScrollBarVisibility="Auto"
+                                         TextWrapping="Wrap"
+                                         MinWidth="120"
+                                         Padding="6"/>
+                                <Button x:Name="CopyCSharpButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding FontIconCSharp, Mode=OneWay}">
+                                    <Grid>
+                                        <ui:FontIcon x:Name="FontIcon_CopyCSharp_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyCSharp_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                        <ui:FontIcon x:Name="FontIcon_CopyCSharp_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                            <FrameworkElement.RenderTransform>
+                                                <ScaleTransform x:Name="ScaleTransform_CopyCSharp_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                            </FrameworkElement.RenderTransform>
+                                        </ui:FontIcon>
+                                    </Grid>
+                                </Button>
+                            </Grid>
+
+                            <StackPanel x:Name="SymbolPanel">
+                                <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="SymbolIcon XAML" />
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox x:Name="SymbolIconXamlBox" Text="{Binding SymbolIconXaml, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                                         FontSize="{DynamicResource ControlContentThemeFontSize}"
+                                                         IsReadOnly="True"
+                                                         BorderThickness="0"
+                                                         Background="Transparent"
+                                                         IsReadOnlyCaretVisible="False"
+                                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                         TextAlignment="Left"
+                                                         VerticalAlignment="Center"
+                                                         VerticalContentAlignment="Center"
+                                                         HorizontalScrollBarVisibility="Hidden"
+                                                         TextWrapping="NoWrap"
+                                                         MinWidth="120"/>
+                                    <Button x:Name="CopySymbolXamlButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding SymbolIconXaml, Mode=OneWay}">
+                                        <Grid>
+                                            <ui:FontIcon x:Name="FontIcon_CopySymbolXaml_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                                <FrameworkElement.RenderTransform>
+                                                    <ScaleTransform x:Name="ScaleTransform_CopySymbolXaml_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                                </FrameworkElement.RenderTransform>
+                                            </ui:FontIcon>
+                                            <ui:FontIcon x:Name="FontIcon_CopySymbolXaml_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                                <FrameworkElement.RenderTransform>
+                                                    <ScaleTransform x:Name="ScaleTransform_CopySymbolXaml_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                                </FrameworkElement.RenderTransform>
+                                            </ui:FontIcon>
+                                        </Grid>
+                                    </Button>
+                                </Grid>
+
+                                <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="SymbolIcon C#" />
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox x:Name="SymbolIconCSharpBox" Text="{Binding SymbolIconCSharp, Mode=OneWay}" FontFamily="Consolas" Margin="-10,0,0,0"
+                                                         FontSize="{DynamicResource ControlContentThemeFontSize}"
+                                                         IsReadOnly="True"
+                                                         BorderThickness="0"
+                                                         Background="Transparent"
+                                                         IsReadOnlyCaretVisible="False"
+                                                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                         TextAlignment="Left"
+                                                         VerticalAlignment="Center"
+                                                         VerticalContentAlignment="Center"
+                                                         HorizontalScrollBarVisibility="Hidden"
+                                                         TextWrapping="NoWrap"
+                                                         MinWidth="120"/>
+                                    <Button x:Name="CopySymbolCSharpButton" Grid.Column="1" Margin="8,0,8,0" Padding="6" Click="CopyValueButton_Click" ToolTipService.ToolTip="Copy to clipboard" AutomationProperties.Name="Copy value" Tag="{Binding SymbolIconCSharp, Mode=OneWay}">
+                                        <Grid>
+                                            <ui:FontIcon x:Name="FontIcon_CopySymbolCSharp_Copy" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.Copy}" RenderTransformOrigin="0.5 0.5">
+                                                <FrameworkElement.RenderTransform>
+                                                    <ScaleTransform x:Name="ScaleTransform_CopySymbolCSharp_Copy" ScaleX="1" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                                </FrameworkElement.RenderTransform>
+                                            </ui:FontIcon>
+                                            <ui:FontIcon x:Name="FontIcon_CopySymbolCSharp_Success" FontSize="16" Icon="{x:Static ui:SegoeFluentIcons.CheckMark}" RenderTransformOrigin="0.5 0.5">
+                                                <FrameworkElement.RenderTransform>
+                                                    <ScaleTransform x:Name="ScaleTransform_CopySymbolCSharp_Success" ScaleX="0" ScaleY="{Binding ScaleX, RelativeSource={RelativeSource Self}}"/>
+                                                </FrameworkElement.RenderTransform>
+                                            </ui:FontIcon>
+                                        </Grid>
+                                    </Button>
+                                </Grid>
+                            </StackPanel>
+
+                            <TextBlock x:Name="TagsLabel" Margin="0,4,0,0" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" Text="Tags" />
+                            <ui:ItemsRepeater x:Name="TagsItemsView" Margin="0,8,0,4" ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}">
+                                <ui:ItemsRepeater.Layout>
+                                        <ui:FlowLayout Orientation="Horizontal" MinColumnSpacing="8" MinRowSpacing="6"/>
+                                    </ui:ItemsRepeater.Layout>
+                                <ui:ItemsRepeater.ItemTemplate>
+                                    <DataTemplate>
+                                        <!-- Use a Button with a local ControlTemplate that only affects
+                                             opacity so the chip remains stable in size while preserving
+                                             Button semantics (keyboard/automation). -->
+                                        <Button Style="{StaticResource TagChipButtonStyle}"
+                                                Click="TagButton_Click"
+                                                MinHeight="24"
+                                                MinWidth="44"
+                                                HorizontalAlignment="Left"
+                                                ToolTipService.ToolTip="{Binding}">
+                                                <TextBlock VerticalAlignment="Center"
+                                                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                                        Text="{Binding}"
+                                                        TextTrimming="CharacterEllipsis"
+                                                        TextWrapping="NoWrap" />
+                                        </Button>
+                                    </DataTemplate>
+                                </ui:ItemsRepeater.ItemTemplate>
+                            </ui:ItemsRepeater>
+                            <TextBlock x:Name="NoTagsTextBlock" Grid.Row="1" Margin="0,4,0,0" Text="No tags available." Visibility="Collapsed" />
+                        </StackPanel>
+                    </ScrollViewer>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+</ui:Page>

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Foundation/Design/IconographyPage.xaml.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Foundation/Design/IconographyPage.xaml.cs
@@ -1,0 +1,505 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using iNKORE.UI.WPF.Modern.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using iNKORE.UI.WPF.Modern.Gallery.Helpers;
+using iNKORE.UI.WPF.Modern.Gallery.DataModel;
+using iNKORE.UI.WPF.Modern;
+using System.Windows.Media.Animation;
+using System.Collections.ObjectModel;
+using System.Windows.Media;
+using System.Diagnostics;
+using System.Windows.Navigation;
+
+namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Foundation
+{
+    public partial class IconographyPage : iNKORE.UI.WPF.Modern.Controls.Page
+    {
+        public List<double> FontSizes { get; } = new()
+        {
+            16,
+            24,
+            32,
+            48
+        };
+
+        private string currentSearch = null;
+
+        public IconData SelectedItem
+        {
+            get { return (IconData)GetValue(SelectedItemProperty); }
+            set
+            {
+                SetValue(SelectedItemProperty, value);
+                SetSampleCodePresenterCode(value);
+            }
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            try
+            {
+                var uri = e.Uri?.AbsoluteUri ?? (sender as System.Windows.Documents.Hyperlink)?.NavigateUri?.AbsoluteUri;
+                if (!string.IsNullOrEmpty(uri))
+                {
+                    var psi = new ProcessStartInfo(uri) { UseShellExecute = true };
+                    Process.Start(psi);
+                }
+            }
+            catch
+            {
+            }
+            e.Handled = true;
+        }
+
+        public static readonly DependencyProperty SelectedItemProperty = DependencyProperty.Register("SelectedItem", typeof(IconData), typeof(IconographyPage), new PropertyMetadata(null, OnSelectedItemChanged));
+
+        private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is IconographyPage page)
+            {
+                try
+                {
+                    page.UpdateSelectionVisuals(e.NewValue as IconData);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public IconographyPage()
+        {
+            InitializeComponent();
+            Loaded += IconographyPage_Loaded;
+            DataContext = this;
+        }
+
+        private void TogglePageTheme()
+        {
+            // Toggle requested theme only on the example container Border so
+            // only the interior region re-evaluates DynamicResource brushes.
+            try
+            {
+                var exampleBorder = FindName("ExampleContainerBorder") as FrameworkElement;
+                if (exampleBorder != null)
+                {
+                    exampleBorder.ToggleTheme();
+                    return;
+                }
+
+                // Fallback to toggling the whole page if the named Border isn't found
+                this.LayoutRoot.ToggleTheme();
+            }
+            catch { }
+        }
+
+        // Dependency properties for side panel sample text
+        public string FontIconXaml
+        {
+            get => (string)GetValue(FontIconXamlProperty);
+            set => SetValue(FontIconXamlProperty, value);
+        }
+        public static readonly DependencyProperty FontIconXamlProperty = DependencyProperty.Register(nameof(FontIconXaml), typeof(string), typeof(IconographyPage), new PropertyMetadata(string.Empty));
+
+        public string FontIconCSharp
+        {
+            get => (string)GetValue(FontIconCSharpProperty);
+            set => SetValue(FontIconCSharpProperty, value);
+        }
+        public static readonly DependencyProperty FontIconCSharpProperty = DependencyProperty.Register(nameof(FontIconCSharp), typeof(string), typeof(IconographyPage), new PropertyMetadata(string.Empty));
+
+        public string SymbolIconXaml
+        {
+            get => (string)GetValue(SymbolIconXamlProperty);
+            set => SetValue(SymbolIconXamlProperty, value);
+        }
+        public static readonly DependencyProperty SymbolIconXamlProperty = DependencyProperty.Register(nameof(SymbolIconXaml), typeof(string), typeof(IconographyPage), new PropertyMetadata(string.Empty));
+
+        public string SymbolIconCSharp
+        {
+            get => (string)GetValue(SymbolIconCSharpProperty);
+            set => SetValue(SymbolIconCSharpProperty, value);
+        }
+        public static readonly DependencyProperty SymbolIconCSharpProperty = DependencyProperty.Register(nameof(SymbolIconCSharp), typeof(string), typeof(IconographyPage), new PropertyMetadata(string.Empty));
+
+        private void IconographyPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (NavigationRootPage.Current?.NavigationView != null)
+            {
+                NavigationRootPage.Current.NavigationView.Header = "Iconography";
+            }
+            
+            // Register toggle theme action on page header so Theme toggle also affects this page
+            try
+            {
+                if (NavigationRootPage.Current?.PageHeader != null)
+                {
+                    NavigationRootPage.Current.PageHeader.ToggleThemeAction = TogglePageTheme;
+                }
+            }
+            catch { }
+
+            // Load icons on a background thread and assign them immediately to the repeater.
+            Task.Run(async delegate
+            {
+                var icons = await IconsDataSource.Instance.LoadIcons();
+
+                // Assign the full list to the ItemsRepeater on the UI thread.
+                await Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    var iconsItemsView = FindName("IconsItemsView") as iNKORE.UI.WPF.Modern.Controls.ItemsRepeater;
+                    if (iconsItemsView != null)
+                    {
+                        iconsItemsView.ItemsSource = icons;
+
+                        // Select the first item by default and show side panel
+                        if (icons != null && icons.Count > 0)
+                        {
+                            var first = icons[0];
+                            SelectedItem = first;
+                            var sidePanel = FindName("SidePanel") as Border;
+                            if (sidePanel != null)
+                            {
+                                sidePanel.Visibility = Visibility.Visible;
+                            }
+                            UpdateSelectionVisuals(first);
+                        }
+                    }
+                }));
+            });
+        }
+
+        private void SetSampleCodePresenterCode(IconData value)
+        {
+            // Update presenters and side panel when selection changes
+            var sidePanel = FindName("SidePanel") as Border;
+            if (value == null)
+            {
+                if (sidePanel != null)
+                {
+                    sidePanel.Visibility = Visibility.Collapsed;
+                }
+                return;
+            }
+
+            // Ensure side panel visible
+            if (sidePanel != null)
+            {
+                sidePanel.Visibility = Visibility.Visible;
+            }
+
+            // Populate code strings for TextBoxes
+            FontIconXaml = $"<FontIcon Glyph=\"{value.TextGlyph}\" />";
+            FontIconCSharp = "FontIcon icon = new FontIcon();" + Environment.NewLine + $"icon.Glyph = \"{value.CodeGlyph}\";";
+
+            if (!string.IsNullOrEmpty(value.SymbolName))
+            {
+                SymbolIconXaml = $"<SymbolIcon Symbol=\"{value.SymbolName}\" />";
+                SymbolIconCSharp = "SymbolIcon icon = new SymbolIcon();" + Environment.NewLine + $"icon.Symbol = Symbol.{value.SymbolName};";
+                var symbolPanel = FindName("SymbolPanel") as StackPanel;
+                if (symbolPanel != null)
+                {
+                    symbolPanel.Visibility = Visibility.Visible;
+                }
+            }
+            else
+            {
+                SymbolIconXaml = string.Empty;
+                SymbolIconCSharp = string.Empty;
+                var symbolPanel = FindName("SymbolPanel") as StackPanel;
+                if (symbolPanel != null)
+                {
+                    symbolPanel.Visibility = Visibility.Collapsed;
+                }
+            }
+
+            // Tags visibility
+            try
+            {
+                if (value.Tags == null || value.Tags.Length == 0 || value.Tags.All(t => string.IsNullOrWhiteSpace(t)))
+                {
+                    TagsItemsView.Visibility = Visibility.Collapsed;
+                    NoTagsTextBlock.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    TagsItemsView.Visibility = Visibility.Visible;
+                    NoTagsTextBlock.Visibility = Visibility.Collapsed;
+                }
+            }
+            catch { }
+        }
+
+        private void SearchTextBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            Filter(IconsSearchBox.Text);
+        }
+
+        public void Filter(string search)
+        {
+            currentSearch = search;
+            string[] filter = search?.Split(' ');
+
+            Task.Run(() =>
+            {
+                var newItems = new List<IconData>();
+                foreach (var item in IconsDataSource.Icons)
+                {
+                    var fitsFilter = filter == null || filter.All(entry =>
+                        item.Code.Contains(entry, StringComparison.CurrentCultureIgnoreCase) ||
+                        item.Name.Contains(entry, StringComparison.CurrentCultureIgnoreCase) ||
+                        item.Tags.Any(tag => !string.IsNullOrEmpty(tag) && tag.Contains(entry, StringComparison.CurrentCultureIgnoreCase)));
+
+                    if (fitsFilter)
+                    {
+                        newItems.Add(item);
+                    }
+                }
+
+                // Assign filtered list to repeater immediately on UI thread
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    var iconsItemsView = FindName("IconsItemsView") as iNKORE.UI.WPF.Modern.Controls.ItemsRepeater;
+                    if (iconsItemsView != null)
+                    {
+                        iconsItemsView.ItemsSource = newItems;
+                        if (newItems.Count > 0)
+                        {
+                            SelectedItem = newItems[0];
+                            UpdateSelectionVisuals(newItems[0]);
+                        }
+                    }
+                }));
+            });
+        }
+
+        private void IconsItemsView_SelectionChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                // Try to read a SelectedItem property from the sender (GridView exposes this)
+                var selProp = IconsItemsView.GetType().GetProperty("SelectedItem");
+                if (selProp != null)
+                {
+                    var sel = selProp.GetValue(IconsItemsView) as IconData;
+                    if (sel != null) SelectedItem = sel;
+                }
+            }
+            catch { }
+
+            try
+            {
+                var argsType = e.GetType();
+                var invokedProp = argsType.GetProperty("InvokedItem");
+                if (invokedProp != null)
+                {
+                    var tag = invokedProp.GetValue(e) as string;
+                    if (!string.IsNullOrEmpty(tag))
+                    {
+                        IconsSearchBox.Text = tag;
+                    }
+                }
+            }
+            catch { }
+        }
+
+        private void IconsItemsView_ItemClicked(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is Button btn && btn.DataContext is IconData data)
+                {
+                    SelectedItem = data;
+                    UpdateSelectionVisuals(data);
+                }
+            }
+            catch { }
+        }
+
+        private void TagButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is Button btn)
+                {
+                    // The TextBlock is inside the Button's visual tree; find it
+                    var tb = FindDescendants<TextBlock>(btn).FirstOrDefault();
+                    var tag = tb?.Text;
+                    if (!string.IsNullOrEmpty(tag))
+                    {
+                        // Update search box text via the named control if available
+                        var searchBoxField = this.GetType().GetField("IconsSearchBox", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+                        if (searchBoxField != null)
+                        {
+                            var searchBox = searchBoxField.GetValue(this);
+                            if (searchBox != null)
+                            {
+                                var textProp = searchBox.GetType().GetProperty("Text");
+                                textProp?.SetValue(searchBox, tag);
+                                var focusMethod = searchBox.GetType().GetMethod("Focus", System.Type.EmptyTypes);
+                                focusMethod?.Invoke(searchBox, null);
+
+                                // Try to open suggestion list if property exists
+                                var isOpenProp = searchBox.GetType().GetProperty("IsSuggestionListOpen");
+                                if (isOpenProp != null) isOpenProp.SetValue(searchBox, true);
+                            }
+                        }
+
+                        // Also call Filter to update items immediately
+                        Filter(tag);
+                    }
+                }
+            }
+            catch { }
+        }
+
+        // handler for Border-based tag chips. Extracts the tag text and
+        // performs the same actions as TagButton_Click (populate search box,
+        // focus, open suggestions, and filter).
+        private void TagChip_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                if (sender is Border outerBorder)
+                {
+                    // The inner TextBlock is a descendant; find it
+                    var tb = FindDescendants<TextBlock>(outerBorder).FirstOrDefault();
+                    var tag = tb?.Text;
+                    if (!string.IsNullOrEmpty(tag))
+                    {
+                        // Reuse the same reflection-based logic to set the search box
+                        var searchBoxField = this.GetType().GetField("IconsSearchBox", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+                        if (searchBoxField != null)
+                        {
+                            var searchBox = searchBoxField.GetValue(this);
+                            if (searchBox != null)
+                            {
+                                var textProp = searchBox.GetType().GetProperty("Text");
+                                textProp?.SetValue(searchBox, tag);
+                                var focusMethod = searchBox.GetType().GetMethod("Focus", System.Type.EmptyTypes);
+                                focusMethod?.Invoke(searchBox, null);
+
+                                // Try to open suggestion list if property exists
+                                var isOpenProp = searchBox.GetType().GetProperty("IsSuggestionListOpen");
+                                if (isOpenProp != null) isOpenProp.SetValue(searchBox, true);
+                            }
+                        }
+
+                        // Also call Filter to update items immediately
+                        Filter(tag);
+                    }
+                }
+            }
+            catch { }
+        }
+
+        private async void CopyValueButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is Button btn && btn.Tag is string tagText)
+                {
+                    Clipboard.SetText(tagText);
+                }
+            }
+            catch (Exception ex)
+            {
+                iNKORE.UI.WPF.Modern.Controls.MessageBox.Show(ex.ToString(), "Unable to Perform Copy", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            // Trigger the Geometry-style copy confirmation animation.
+            // The VisualStateGroups are declared on LayoutRoot; use GoToElementState
+            // so the states are found in the same namescope.
+            if (sender is Button)
+            {
+                try
+                {
+                        var layoutRoot = FindName("LayoutRoot") as FrameworkElement;
+                        if (layoutRoot != null)
+                        {
+                            // If the Button has a name like "CopyXamlButton" derive a per-button
+                            // state name like "CopyXamlVisible" and "CopyXamlHidden" and try
+                            // to trigger it. Fall back to the shared Control/Overlay groups.
+                            if (sender is Button btn && !string.IsNullOrEmpty(btn.Name))
+                            {
+                                // Strip trailing "Button" if present
+                                var baseName = btn.Name.EndsWith("Button") ? btn.Name.Substring(0, btn.Name.Length - 6) : btn.Name;
+                                var visibleState = baseName + "Visible";
+                                var hiddenState = baseName + "Hidden";
+
+                                var started = VisualStateManager.GoToElementState(layoutRoot, visibleState, true);
+                                if (!started)
+                                {
+                                    // fall back to existing Control/Overlay groups
+                                    started = VisualStateManager.GoToElementState(layoutRoot, "ControlCornerRadiusCopyButtonVisible", true);
+                                    if (!started)
+                                    {
+                                        VisualStateManager.GoToElementState(layoutRoot, "OverlayCornerRadiusCopyButtonVisible", true);
+                                    }
+                                }
+
+                                // Revert after a short delay so the success checkmark animates back.
+                                await Task.Delay(900);
+
+                                // Try to revert per-button state first, then the shared states.
+                                VisualStateManager.GoToElementState(layoutRoot, hiddenState, true);
+                                VisualStateManager.GoToElementState(layoutRoot, "ControlCornerRadiusCopyButtonHidden", true);
+                                VisualStateManager.GoToElementState(layoutRoot, "OverlayCornerRadiusCopyButtonHidden", true);
+                            }
+                            else
+                            {
+                                var started = VisualStateManager.GoToElementState(layoutRoot, "ControlCornerRadiusCopyButtonVisible", true);
+                                if (!started)
+                                {
+                                    VisualStateManager.GoToElementState(layoutRoot, "OverlayCornerRadiusCopyButtonVisible", true);
+                                }
+                                await Task.Delay(900);
+                                VisualStateManager.GoToElementState(layoutRoot, "ControlCornerRadiusCopyButtonHidden", true);
+                                VisualStateManager.GoToElementState(layoutRoot, "OverlayCornerRadiusCopyButtonHidden", true);
+                            }
+                        }
+                }
+                catch
+                {
+                    // Swallow any VSM exceptions; copy already occurred.
+                }
+            }
+        }
+
+        // Recursive descendant finder
+        private static IEnumerable<T> FindDescendants<T>(DependencyObject root) where T : DependencyObject
+        {
+            if (root == null) yield break;
+
+            var queue = new Queue<DependencyObject>();
+            queue.Enqueue(root);
+
+            while (queue.Count > 0)
+            {
+                var current = queue.Dequeue();
+                int count = VisualTreeHelper.GetChildrenCount(current);
+                for (int i = 0; i < count; i++)
+                {
+                    var child = VisualTreeHelper.GetChild(current, i);
+                    if (child is T t) yield return t;
+                    queue.Enqueue(child);
+                }
+            }
+        }
+
+        //Keep for reference in the future
+        private void UpdateSelectionVisuals(IconData selected)
+        {
+
+        }
+    }
+}

--- a/source/iNKORE.UI.WPF.Modern.Gallery/iNKORE.UI.WPF.Modern.Gallery.csproj
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/iNKORE.UI.WPF.Modern.Gallery.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -98,6 +98,7 @@
     <Resource Include="DataModel\Data\Controls.Community.json" />
     <Resource Include="DataModel\Data\Controls.Extended.json" />
     <Resource Include="DataModel\Data\Controls.Foundation.json" />
+  <EmbeddedResource Include="DataModel\IconsData.json" />
     <Resource Include="DataModel\Data\Controls.Windows.json" />
   </ItemGroup>
 


### PR DESCRIPTION
Due to the current absence of Item View #341, the icon is displayed using an item repeater with a button as a template. I have already attempted using GridView, but the performance is terrible, with a 4-second freeze every time a load or search is initiated.

I also noticed that the hyperlink displayed under the settings expander was not automatically themed to use Fluent Design, so i just customized hyperlink button as work around.

<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/9bfc03bf-46ed-44c7-a06f-ae7c68bfe9f8" />
<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/a3dedcf5-ada2-4428-818c-19402f4d1de2" />
<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/a1fa3a5e-8ace-4392-a0d4-ba88a068f97e" />
<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/acbd1cff-f120-492e-b17a-7aa797a50151" />