### PR TITLE
[Fix] Context Menu: Remove tab navigation for context menu & menu items

### DIFF
--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/ContextMenu.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/ContextMenu.xaml
@@ -51,7 +51,7 @@
                                 Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer,
                                                                               TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                 <ItemsPresenter
-                                    KeyboardNavigation.DirectionalNavigation="None"
+                                    KeyboardNavigation.DirectionalNavigation="Cycle"
                                     KeyboardNavigation.TabNavigation="None"
                                     RenderOptions.ClearTypeHint="Enabled"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />

--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/ContextMenu.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/ContextMenu.xaml
@@ -17,6 +17,9 @@
         <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="FontStyle" Value="Normal" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
+        <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Grid.IsSharedSizeScope" Value="true" />
         <Setter Property="HasDropShadow" Value="{DynamicResource {x:Static SystemParameters.DropShadowKey}}" />
@@ -48,7 +51,8 @@
                                 Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer,
                                                                               TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                 <ItemsPresenter
-                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    KeyboardNavigation.DirectionalNavigation="None"
+                                    KeyboardNavigation.TabNavigation="None"
                                     RenderOptions.ClearTypeHint="Enabled"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </local:ScrollViewerEx>

--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
@@ -342,7 +342,7 @@
                                 <ItemsPresenter
                                     Grid.IsSharedSizeScope="true"
                                     KeyboardNavigation.DirectionalNavigation="Cycle"
-                                    KeyboardNavigation.TabNavigation="Cycle"
+                                    KeyboardNavigation.TabNavigation="None"
                                     RenderOptions.ClearTypeHint="Enabled"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </local:ScrollViewerEx>

--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
@@ -402,8 +402,6 @@
         <Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePadding}" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />

--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
@@ -407,6 +407,8 @@
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="chelper:ControlHelper.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
+        <Setter Property="chelper:FocusVisualHelper.UseSystemFocusVisuals" Value="{DynamicResource UseSystemFocusVisuals}" />
         <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type MenuItem}, ResourceId=SubmenuItemTemplateKey}}" />
         <Style.Triggers>
             <Trigger Property="Role" Value="TopLevelHeader">

--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
@@ -126,7 +126,7 @@
                                 <ItemsPresenter
                                     Grid.IsSharedSizeScope="true"
                                     KeyboardNavigation.DirectionalNavigation="Cycle"
-                                    KeyboardNavigation.TabNavigation="Cycle"
+                                    KeyboardNavigation.TabNavigation="None"
                                     RenderOptions.ClearTypeHint="Enabled"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </local:ScrollViewerEx>

--- a/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
+++ b/source/iNKORE.UI.WPF.Modern/Themes/Controls/MenuItem.xaml
@@ -402,12 +402,13 @@
         <Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePadding}" />
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="chelper:ControlHelper.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
-        <Setter Property="chelper:FocusVisualHelper.UseSystemFocusVisuals" Value="{DynamicResource UseSystemFocusVisuals}" />
         <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type MenuItem}, ResourceId=SubmenuItemTemplateKey}}" />
         <Style.Triggers>
             <Trigger Property="Role" Value="TopLevelHeader">
@@ -416,7 +417,6 @@
                 <Setter Property="BorderThickness" Value="{DynamicResource MenuBarItemBorderThickness}" />
                 <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type MenuItem}, ResourceId=TopLevelHeaderTemplateKey}}" />
                 <Setter Property="VerticalContentAlignment" Value="Stretch" />
-                <Setter Property="IsTabStop" Value="True" />
                 <Setter Property="Header" Value="Item" />
                 <Setter Property="Height" Value="{DynamicResource MenuBarHeight}" />
             </Trigger>
@@ -426,7 +426,6 @@
                 <Setter Property="BorderThickness" Value="{DynamicResource MenuBarItemBorderThickness}" />
                 <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type MenuItem}, ResourceId=TopLevelItemTemplateKey}}" />
                 <Setter Property="VerticalContentAlignment" Value="Stretch" />
-                <Setter Property="IsTabStop" Value="True" />
                 <Setter Property="Header" Value="Item" />
                 <Setter Property="Height" Value="{DynamicResource MenuBarHeight}" />
             </Trigger>


### PR DESCRIPTION
In WinUI3, `MenuFlyout` does not support tab navigation. Also, `ContextMenu` does not support tab navigation.

# TODO

- [ ] Wait #282 to be merged.
- [ ] Fix issue that press tab will make focus visual be displayed for menu items.