### PR TITLE
Gallery-Fix: InfoBar width gets increased when changing severity on InfoBarPage 

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/InfoBarPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/InfoBarPage.xaml
@@ -1,4 +1,4 @@
-﻿<ui:Page
+<ui:Page
     x:Class="iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows.InfoBarPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -30,7 +30,7 @@
 
             </local:ControlExample.Example>
             <local:ControlExample.Options>
-                <StackPanel>
+                <StackPanel Width="150">
                     <CheckBox
                         x:Name="IsOpenCheckBox1"
                         Content="Is Open"
@@ -38,6 +38,7 @@
                         Click="CheckBox_Click"/>
                     <ComboBox
                         x:Name="SeverityComboBox"
+                        HorizontalAlignment="Stretch"
                         ui:ControlHelper.Header="Severity"
                         SelectedValue="Informational"
                         SelectionChanged="SeverityComboBox_SelectionChanged">
@@ -67,7 +68,7 @@
                     IsOpen="True" />
             </local:ControlExample.Example>
             <local:ControlExample.Options>
-                <StackPanel>
+                <StackPanel Width="150">
                     <CheckBox
                         x:Name="IsOpenCheckBox2"
                         Content="Is Open"
@@ -76,6 +77,7 @@
 
                     <ComboBox
                         x:Name="MessageComboBox"
+                        HorizontalAlignment="Stretch"
                         ui:ControlHelper.Header="Message Length"
                         SelectedIndex="1"
                         SelectionChanged="MessageComboBox_SelectionChanged">
@@ -84,6 +86,7 @@
                     </ComboBox>
                     <ComboBox
                         x:Name="ActionButtonComboBox"
+                        HorizontalAlignment="Stretch"
                         ui:ControlHelper.Header="Action Button"
                         SelectedIndex="0"
                         SelectionChanged="ActionButtonComboBox_SelectionChanged">
@@ -115,7 +118,7 @@
                     Message="Essential app message for your users to be informed of, acknowledge, or take action on." />
             </local:ControlExample.Example>
             <local:ControlExample.Options>
-                <StackPanel>
+                <StackPanel Width="150">
                     <CheckBox
                         x:Name="IsOpenCheckBox3"
                         Content="Is Open"


### PR DESCRIPTION
Fix InfoBar width increases when switching severity modes by adjusting StackPanel widths and alignments in InfoBarPage, by following the WinUI3 Gallery layout