### PR TITLE
Use default names when MB_GetString doesn't exist

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Extended/MessageBox/LocalizedDialogCommands.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Extended/MessageBox/LocalizedDialogCommands.cs
@@ -7,6 +7,10 @@ namespace iNKORE.UI.WPF.Modern.Controls
 {
     internal static class LocalizedDialogCommands
     {
+        /// <summary>
+        /// Fallback display strings for standard dialog box commands
+        /// when localized resources are unavailable or the native API call fails.
+        /// </summary>
         internal static readonly Dictionary<DialogBoxCommand, string> FallbackStrings = new()
         {
             { DialogBoxCommand.IDOK, "OK" },

--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Extended/MessageBox/LocalizedDialogCommands.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Extended/MessageBox/LocalizedDialogCommands.cs
@@ -8,7 +8,29 @@ namespace iNKORE.UI.WPF.Modern.Controls
     {
         public static string GetString(DialogBoxCommand command)
         {
-            return Marshal.PtrToStringAuto(MB_GetString((int)command))?.Replace("&", "")!; //return Marshal.PtrToStringAuto(MB_GetString((int)command))?.TrimStart('&')!;
+            try
+            {
+                //return Marshal.PtrToStringAuto(MB_GetString((int)command))?.TrimStart('&')!;
+                return Marshal.PtrToStringAuto(MB_GetString((int)command))?.Replace("&", "")!;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return command switch
+                {
+                    DialogBoxCommand.IDOK => "Ok",
+                    DialogBoxCommand.IDCANCEL => "Cancel",
+                    DialogBoxCommand.IDABORT => "Abort",
+                    DialogBoxCommand.IDRETRY => "Retry",
+                    DialogBoxCommand.IDIGNORE => "Ignore",
+                    DialogBoxCommand.IDYES => "Yes",
+                    DialogBoxCommand.IDNO => "No",
+                    DialogBoxCommand.IDCLOSE => "Close",
+                    DialogBoxCommand.IDHELP => "Help",
+                    DialogBoxCommand.IDTRYAGAIN => "Try Again",
+                    DialogBoxCommand.IDCONTINUE => "Continue",
+                    _ => command.ToString()
+                };
+            }
         }
 
         /// <summary>

--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Extended/MessageBox/LocalizedDialogCommands.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Extended/MessageBox/LocalizedDialogCommands.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace iNKORE.UI.WPF.Modern.Controls
@@ -6,6 +7,21 @@ namespace iNKORE.UI.WPF.Modern.Controls
 {
     internal static class LocalizedDialogCommands
     {
+        internal static readonly Dictionary<DialogBoxCommand, string> FallbackStrings = new()
+        {
+            { DialogBoxCommand.IDOK, "OK" },
+            { DialogBoxCommand.IDCANCEL, "Cancel" },
+            { DialogBoxCommand.IDABORT, "Abort" },
+            { DialogBoxCommand.IDRETRY, "Retry" },
+            { DialogBoxCommand.IDIGNORE, "Ignore" },
+            { DialogBoxCommand.IDYES, "Yes" },
+            { DialogBoxCommand.IDNO, "No" },
+            { DialogBoxCommand.IDCLOSE, "Close" },
+            { DialogBoxCommand.IDHELP, "Help" },
+            { DialogBoxCommand.IDTRYAGAIN, "Try Again" },
+            { DialogBoxCommand.IDCONTINUE, "Continue" }
+        };
+
         public static string GetString(DialogBoxCommand command)
         {
             try
@@ -15,21 +31,9 @@ namespace iNKORE.UI.WPF.Modern.Controls
             }
             catch (EntryPointNotFoundException)
             {
-                return command switch
-                {
-                    DialogBoxCommand.IDOK => "Ok",
-                    DialogBoxCommand.IDCANCEL => "Cancel",
-                    DialogBoxCommand.IDABORT => "Abort",
-                    DialogBoxCommand.IDRETRY => "Retry",
-                    DialogBoxCommand.IDIGNORE => "Ignore",
-                    DialogBoxCommand.IDYES => "Yes",
-                    DialogBoxCommand.IDNO => "No",
-                    DialogBoxCommand.IDCLOSE => "Close",
-                    DialogBoxCommand.IDHELP => "Help",
-                    DialogBoxCommand.IDTRYAGAIN => "Try Again",
-                    DialogBoxCommand.IDCONTINUE => "Continue",
-                    _ => command.ToString()
-                };
+                return FallbackStrings.TryGetValue(command, out var value)
+                    ? value
+                    : command.ToString();
             }
         }
 


### PR DESCRIPTION
Hello,
The library uses the `MB_GetString` function to get default names for the buttons for the message boxes.
It works fine on Windows. But in Wine on Linux the function is not implemented.
See https://github.com/wine-mirror/wine/blob/cec314f2b26ad44be666ddd034ee269f6bb6215a/dlls/user32/user32.spec#L848
This PR uses default names when the function does not exist. In this case a `EntryPointNotFoundException` exception is thrown and the code catches it to set default strings.
