### PR TITLE
Fix compilation of 0.10.2 under msbuild.exe due to inaccessible `CloseTabButtonCommandProperty` member.

### DIFF
--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/TabItemHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/TabItemHelper.cs
@@ -148,18 +148,18 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
 
         #region CloseTabButtonCommand
 
-        internal static readonly DependencyProperty CloseTabButtonCommandProperty = DependencyProperty.RegisterAttached(
+        public static readonly DependencyProperty CloseTabButtonCommandProperty = DependencyProperty.RegisterAttached(
             "CloseTabButtonCommand",
             typeof(ICommand),
             typeof(TabItemHelper),
             null);
 
-        internal static ICommand GetCloseTabButtonCommand(TabItem element)
+        public static ICommand GetCloseTabButtonCommand(TabItem element)
         {
             return (ICommand)element.GetValue(CloseTabButtonCommandProperty);
         }
 
-        internal static void SetCloseTabButtonCommand(TabItem tabItem, ICommand value)
+        public static void SetCloseTabButtonCommand(TabItem tabItem, ICommand value)
         {
             tabItem.SetValue(CloseTabButtonCommandProperty, value);
         }


### PR DESCRIPTION
```
Restore complete (3.5s)
  iNKORE.UI.WPF net472 succeeded (7.6s) → C:\Repos\PSAppDeployToolkit\lib\iNKORE.UI.WPF\source\iNKORE.UI.WPF\bin\Release\net472\iNKORE.UI.WPF.dll
  iNKORE.UI.WPF net8.0-windows succeeded (9.0s) → C:\Repos\PSAppDeployToolkit\lib\iNKORE.UI.WPF\source\iNKORE.UI.WPF\bin\Release\net8.0-windows\iNKORE.UI.WPF.dll
  iNKORE.UI.WPF.Modern net472 failed with 1 error(s) (10.9s)
    C:\Repos\PSAppDeployToolkit\lib\iNKORE.UI.WPF.Modern\source\iNKORE.UI.WPF.Modern\Themes\Controls\TabControl.xaml(285,33): error MC3019: Cannot reference the static member 'CloseTabButtonCommandProperty' on the type 'TabItemHelper' as it is not accessible.
  iNKORE.UI.WPF.Modern net8.0-windows10.0.18362.0 failed with 1 error(s) (9.7s)
    C:\Repos\PSAppDeployToolkit\lib\iNKORE.UI.WPF.Modern\source\iNKORE.UI.WPF.Modern\Themes\Controls\TabControl.xaml(285,33): error MC3019: Cannot reference the static member 'CloseTabButtonCommandProperty' on the type 'TabItemHelper' as it is not accessible.
```