### PR TITLE
Fix expander

### DIFF
--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
@@ -101,7 +101,7 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
 
         private static void OnExpanderExpandedOrCollapsed(object sender, RoutedEventArgs e)
         {
-            if (sender is not Expander expander)
+            if (sender is not Expander expander || !expander.IsLoaded)
             {
                 return;
             }

--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
@@ -178,8 +178,8 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
         {
             var toAnimateControl = GetToAnimateControl(expander);
             toAnimateControl.BeginAnimation(UIElement.VisibilityProperty, null);
-			toAnimateControl.Visibility = Visibility.Visible;
-			UpdateLayout(toAnimateControl);
+            toAnimateControl.Visibility = Visibility.Visible;
+            UpdateLayout(toAnimateControl);
 
             if (toAnimateControl.RenderTransform is not TranslateTransform translateTransform)
             {

--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
@@ -77,26 +77,22 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
                 return;
             }
 
-            if (e.NewValue is not true)
-            {
-                expander.Expanded -= OnExpanderExpandedOrCollapsed;
-                expander.Collapsed -= OnExpanderExpandedOrCollapsed;
-                return;
-            }
+			if (e.NewValue is true)
+			{
+				if (expander.IsLoaded)
+				{
+					InitializeExpanderState(expander);
+				}
+				else
+				{
+					expander.Loaded += TriggerExpandAnimationOnLoad;
+				}
+			}
 
-            expander.Expanded += OnExpanderExpandedOrCollapsed;
-            expander.Collapsed += OnExpanderExpandedOrCollapsed;
+			expander.Expanded += OnExpanderExpandedOrCollapsed;
+			expander.Collapsed += OnExpanderExpandedOrCollapsed;
 
-            if (expander.IsLoaded)
-            {
-                InitializeExpanderState(expander);
-            }
-            else
-            {
-                expander.Loaded += TriggerExpandAnimationOnLoad;
-            }
-
-            void TriggerExpandAnimationOnLoad(object sender, RoutedEventArgs routedEventArgs)
+			void TriggerExpandAnimationOnLoad(object sender, RoutedEventArgs routedEventArgs)
             {
                 InitializeExpanderState(expander);
                 expander.Loaded -= TriggerExpandAnimationOnLoad;
@@ -110,8 +106,14 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
                 return;
             }
 
-            RunExpanderAnimation(expander);
-        }
+			if (GetIsEnabled(expander))
+				RunExpanderAnimation(expander);
+			else
+			{
+				var toAnimateControl = GetToAnimateControl(expander);
+				toAnimateControl?.Visibility = expander.IsExpanded ? Visibility.Visible : Visibility.Collapsed;
+			}
+		}
 
         #endregion
 
@@ -176,7 +178,8 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
         {
             var toAnimateControl = GetToAnimateControl(expander);
             toAnimateControl.BeginAnimation(UIElement.VisibilityProperty, null);
-            UpdateLayout(toAnimateControl);
+			toAnimateControl.Visibility = Visibility.Visible;
+			UpdateLayout(toAnimateControl);
 
             if (toAnimateControl.RenderTransform is not TranslateTransform translateTransform)
             {


### PR DESCRIPTION
In the version currently released on NuGet, when animation is disabled, the expander doesn't expand at all.

After a recent fix for the initial expander state (blinking), expansion doesn't work at all (with or without animation).

This fix fixes this issue.