### PR TITLE
Fix NumberBox style

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NumberBox/NumberBox.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NumberBox/NumberBox.xaml
@@ -56,7 +56,12 @@
                                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                           Focusable="False"
                                                           Text="{TemplateBinding Content}"
+                                                          Foreground="{TemplateBinding Foreground}"
+                                                          FontSize="{TemplateBinding FontSize}"
                                                           FontFamily="{TemplateBinding FontFamily}"
+                                                          FontWeight="{TemplateBinding FontWeight}"
+                                                          FontStyle="{TemplateBinding FontStyle}"
+                                                          FontStretch="{TemplateBinding FontStretch}"
                                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Border>
                         </ui:ElevationBorder>


### PR DESCRIPTION
According to the case reported by @Jack251970 in [reply](https://github.com/iNKORE-NET/UI.WPF.Modern/pull/268#issuecomment-3708180513), it seems in some cases the included merged resource dictionaries don't provide the correct theme resources (it seems to only provide the light theme resources by default?).

This PR uses a custom RepeatButton style that uses the needed resources instead.


Remaining issues:
~~Popup icons.~~

After changes: 

https://github.com/user-attachments/assets/d880a558-4a2a-46e6-aac9-57d75c112115




