### PR TITLE
Fix ProjectReference for samples to use dev library

### DIFF
--- a/samples/ButtonsOnTitlebar/ButtonsOnTitlebar.csproj
+++ b/samples/ButtonsOnTitlebar/ButtonsOnTitlebar.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.9.30" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern\iNKORE.UI.WPF.Modern.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/FlyoutExample/FlyoutExample.csproj
+++ b/samples/FlyoutExample/FlyoutExample.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iNKORE.UI.WPF" Version="1.2.7.1" />
-    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.9.29" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern.Controls\iNKORE.UI.WPF.Modern.Controls.csproj" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern\iNKORE.UI.WPF.Modern.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/NavigationViewExample/NavigationViewExample.csproj
+++ b/samples/NavigationViewExample/NavigationViewExample.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iNKORE.UI.WPF" Version="1.2.7.1" />
-    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.9.30" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern.Controls\iNKORE.UI.WPF.Modern.Controls.csproj" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern\iNKORE.UI.WPF.Modern.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/StarterKit/StarterKit.csproj
+++ b/samples/StarterKit/StarterKit.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iNKORE.UI.WPF" Version="1.2.7.1" />
-    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.9.30" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern.Controls\iNKORE.UI.WPF.Modern.Controls.csproj" />
+    <ProjectReference Include="..\..\source\iNKORE.UI.WPF.Modern\iNKORE.UI.WPF.Modern.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates the project references in several samples to use direct project references instead of NuGet package references.

This change ensures that the samples always use the latest local source code for the `iNKORE.UI.WPF.Modern` and `iNKORE.UI.WPF.Modern.Controls` libraries, which is helpful for development and testing.