### PR TITLE
fix(Expander): respect Windows "Animation effects" setting

### DIFF
--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
@@ -163,7 +163,7 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
 
         private static void RunExpanderAnimation(Expander expander)
         {
-s            if (!Helper.IsAnimationsEnabled)
+            if (!Helper.IsAnimationsEnabled)
             {
                 InitializeExpanderState(expander);
                 return;

--- a/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
+++ b/source/iNKORE.UI.WPF.Modern/Controls/Helpers/ExpanderAnimationsHelper.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
+using iNKORE.UI.WPF.Modern.Helpers;
 
 namespace iNKORE.UI.WPF.Modern.Controls.Helpers
 {
@@ -128,7 +129,6 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
         /// to Collapsed. For expanded expanders, it ensures visibility is Visible and resets
         /// any transforms to identity without animation.
         /// </remarks>
-        /// <seealso href="https://github.com/iNKORE-NET/UI.WPF.Modern/issues/402"/>
         private static void InitializeExpanderState(Expander expander)
         {
             // On initial load, set the content to the appropriate state immediately
@@ -163,6 +163,12 @@ namespace iNKORE.UI.WPF.Modern.Controls.Helpers
 
         private static void RunExpanderAnimation(Expander expander)
         {
+s            if (!Helper.IsAnimationsEnabled)
+            {
+                InitializeExpanderState(expander);
+                return;
+            }
+
             if (expander.IsExpanded)
             {
                 AnimateExpand(expander);


### PR DESCRIPTION
Expander and SettingsExpander always played their expand/collapse animation, ignoring the Windows 11 Accessibility -> Visual effects -> Animation effects setting, unlike NavigationView and other controls.

ExpanderAnimationsHelper.RunExpanderAnimation now checks Helper.IsAnimationsEnabled (SystemParameters.ClientAreaAnimation) and snaps the content to its target state instead of animating when animations are disabled system-wide.

Closes https://github.com/iNKORE-NET/UI.WPF.Modern/issues/430