### PR TITLE
fix(NavigationView): prevent selection indicator from overstretching

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/NavigationView/NavigationView.cs
@@ -2357,9 +2357,13 @@ namespace iNKORE.UI.WPF.Modern.Controls
                 KeyFrames =
                 {
                     new DiscreteDoubleKeyFrame(from < to ? 0.0 : dimension, KeyTime.FromPercent(0.0)),
-                    new DiscreteDoubleKeyFrame(from < to ? dimension : 0.0, KeyTime.FromPercent(1.0)),
+                    // CenterY must reach the far edge before scaleAnim shrinks; otherwise the bar
+                    // scales around its start edge and overshoots. Keep the flip inside the active
+                    // window (0.333) and the clip as long as the settle (600ms) so CenterY stays
+                    // pinned throughout, instead of being held only by FillBehavior after the clip.
+                    new DiscreteDoubleKeyFrame(from < to ? dimension : 0.0, KeyTime.FromPercent(0.333)),
                 },
-                Duration = TimeSpan.FromMilliseconds(200)
+                Duration = TimeSpan.FromMilliseconds(600)
             };
             Storyboard.SetTarget(centerAnim, indicator);
             animations.Add(centerAnim);


### PR DESCRIPTION
Fixes #429, the `NavigationView` selection indicator visibly overstretches past its target during longer selection jumps.

## Cause

`PlayIndicatorAnimations` drives the indicator with three animations that share a 600ms storyboard:

- `scaleAnim` stretches the bar (peak at 33%) then eases it back down to the target over the full 600ms.
- `centerAnim` flips the `ScaleTransform` pivot (`CenterY`/`CenterX`) from the start edge to the far edge, so the shrink phase settles onto the target.

The pivot flip must land **before** the bar shrinks. The old `centerAnim`placed that discrete keyframe on the **last tick** of a  **200ms** clip (`KeyTime.FromPercent(1.0)`, `Duration = 200ms`), after which the pivot was held only by `FillBehavior` for the remaining 400ms. When the compositor mistimes that terminal-tick keyframe (which happens under real-app load, bitmap cache, scrolling pane, high DPI), the pivot stays at the start edge, so the bar scales around it and overshoots the target, the "overstretching" in the report.

## Change

```diff
-    new DiscreteDoubleKeyFrame(from < to ? dimension : 0.0, KeyTime.FromPercent(1.0)),
+    new DiscreteDoubleKeyFrame(from < to ? dimension : 0.0, KeyTime.FromPercent(0.333)),
 },
-Duration = TimeSpan.FromMilliseconds(200)
+Duration = TimeSpan.FromMilliseconds(600)
```

The flip now happens inside the active window and the clip runs as long as the settle, so CenterY is explicitly pinned to the far edge throughout, rather than relying on the fill state of a completed short clip.

> OLD and NEW are value-identical: the fix doesn't change the intended motion. But the overstretch has exactly one cause: the pivot (CenterY) failing to flip before the bar shrinks. OLD parks that flip on the terminal tick of a 200 ms clip and relies on FillBehavior to hold it for the remaining 400 ms: fragile, and it misfires under real-app compositor load (which is why it's intermittent and I couldn't repro it with OLD on a clean harness). NEW moves the flip to 0.333 inside a 600 ms active clip that holds CenterY through the whole settle. So it's a legitimate robustness fix targeting the actual root cause, not luck.