### PR TITLE
fix(HyperlinkButton): raise Click only once, drop RaiseHyperlinkClicks

### DIFF
--- a/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/HyperlinkButton/HyperlinkButton.cs
+++ b/source/iNKORE.UI.WPF.Modern.Controls/Controls/Windows/HyperlinkButton/HyperlinkButton.cs
@@ -36,6 +36,7 @@ namespace iNKORE.UI.WPF.Modern.Controls
                 TargetName = TargetName
             };
             m_hyperlink.RequestNavigate += OnRequestNavigate;
+            m_hyperlink.Click += OnHyperlinkClick;
             AddLogicalChild(m_hyperlink);
         }
 
@@ -49,15 +50,6 @@ namespace iNKORE.UI.WPF.Modern.Controls
             get => (Uri)GetValue(NavigateUriProperty);
             set => SetValue(NavigateUriProperty, value);
         }
-
-        public static readonly DependencyProperty RaiseHyperlinkClicksProperty = DependencyProperty.Register(nameof(RaiseHyperlinkClicks), typeof(bool), typeof(HyperlinkButton), new PropertyMetadata(true));
-
-        public bool RaiseHyperlinkClicks
-        {
-            get => (bool)GetValue(RaiseHyperlinkClicksProperty);
-            set => SetValue(RaiseHyperlinkClicksProperty, value);
-        }
-
 
         private static void OnNavigateUriChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -112,11 +104,20 @@ namespace iNKORE.UI.WPF.Modern.Controls
                     peer.RaiseAutomationEvent(AutomationEvents.InvokePatternOnInvoked);
             }
 
-            if (RaiseHyperlinkClicks)
+            if (NavigateUri != null)
             {
                 m_hyperlink.DoClick();
             }
             base.OnClick();
+        }
+
+        private static void OnHyperlinkClick(object sender, RoutedEventArgs e)
+        {
+            // Hyperlink.ClickEvent is registered as ButtonBase.ClickEvent.AddOwner(typeof(Hyperlink)),
+            // so it is the very same routed event as this button's Click. Because the inner Hyperlink is
+            // a logical child, the Click raised by DoClick() would bubble up and fire the button's own
+            // Click handler an extra time. Mark it handled so navigation still runs but Click fires once.
+            e.Handled = true;
         }
 
         internal void AutomationButtonBaseClick()

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/HyperlinkButtonPage.xaml
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/HyperlinkButtonPage.xaml
@@ -31,7 +31,6 @@
                 <ui:HyperlinkButton
                     x:Name="Control2"
                     Click="GoToHyperlinkButton_Click"
-                    RaiseHyperlinkClicks="False"
                     Content="Go to ToggleButton" />
             </local:ControlExample.Example>
         </local:ControlExample>

--- a/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/HyperlinkButtonPage.xaml.cs
+++ b/source/iNKORE.UI.WPF.Modern.Gallery/Pages/Controls/Windows/HyperlinkButtonPage.xaml.cs
@@ -61,7 +61,6 @@ namespace iNKORE.UI.WPF.Modern.Gallery.Pages.Controls.Windows
         public string Example2Xaml => $@"
 <ui:HyperlinkButton x:Name=""Control2""
     Click=""GoToHyperlinkButton_Click""
-    RaiseHyperlinkClicks=""False""
     Content=""Go to ToggleButton"" />
 ";
 


### PR DESCRIPTION
Hyperlink.ClickEvent is registered as ButtonBase.ClickEvent.AddOwner(...), i.e. it is the very same routed event as the button's own Click. The inner Hyperlink is a logical child, so the Click raised by DoClick() bubbled back up to the HyperlinkButton and fired the user's Click handler a second time on every single click (#407).

Mark the inner Hyperlink's Click as handled so it no longer bubbles: DoClick() still performs navigation while Click is raised exactly once by base.OnClick(). DoClick() is now only invoked when NavigateUri is set.

Remove RaiseHyperlinkClicks: it was a workaround that defaulted to the buggy double-raise behaviour and, when turned off, also disabled navigation because both were coupled to the same DoClick() call.

**⚠️ BREAKING CHANGE**: the RaiseHyperlinkClicks property has been removed. Remove any references to it; the double-Click it worked around no longer occurs.

Fixes #407